### PR TITLE
[#47] As a developer, I can have a CD process to build and deploy the Android app to Firebase App Distribution

### DIFF
--- a/.github/workflows/android_deploy_production.yml
+++ b/.github/workflows/android_deploy_production.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feature/47-setup-cd-to-build-and-deploy-android-app-to-firebase
 
 jobs:
   build_and_deploy_android:

--- a/.github/workflows/android_deploy_production.yml
+++ b/.github/workflows/android_deploy_production.yml
@@ -1,0 +1,57 @@
+name: Android - Deploy Production build to Firebase
+
+on:
+  push:
+    branches:
+      - main
+      - feature/47-setup-cd-to-build-and-deploy-android-app-to-firebase
+
+jobs:
+  build_and_deploy_android:
+    name: Build & Deploy Android
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Set new project
+        run: make run PACKAGE_NAME=co.nimblehq.flutter.template PROJECT_NAME=flutter_templates APP_NAME="Flutter Templates"
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - name: Setup Flutter environment
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          flutter-version: '3.3.10'
+
+      - name: Get flutter dependencies
+        run: flutter pub get
+
+      - name: Run code generator.
+        run: flutter packages pub run build_runner build --delete-conflicting-outputs
+
+      - name: Setup .env
+        env:
+          ENV_PRODUCTION: ${{ secrets.ENV_PRODUCTION }}
+        run: |
+          echo $ENV_PRODUCTION > .env
+
+      # App Bundle requires Firebase connected to Play Store to upload https://appdistribution.page.link/KPoa
+      - name: Build Android apk
+        run: flutter build apk --flavor production --debug --build-number $GITHUB_RUN_NUMBER
+
+      - name: Deploy Android Production to Firebase
+        uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
+        with:
+          appId: ${{secrets.FIREBASE_ANDROID_APP_ID_PRODUCTION}}
+          serviceCredentialsFileContent: ${{secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON}}
+          groups: nimble
+          file: build/app/outputs/flutter-apk/app-production-debug.apk

--- a/.github/workflows/android_deploy_production.yml
+++ b/.github/workflows/android_deploy_production.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Deploy Android Production to Firebase
         uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
         with:
-          appId: ${{secrets.FIREBASE_ANDROID_APP_ID_PRODUCTION}}
-          serviceCredentialsFileContent: ${{secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON}}
+          appId: ${{ secrets.FIREBASE_ANDROID_APP_ID_PRODUCTION }}
+          serviceCredentialsFileContent: ${{ secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON }}
           groups: nimble
           file: build/app/outputs/flutter-apk/app-production-debug.apk

--- a/.github/workflows/android_deploy_production.yml
+++ b/.github/workflows/android_deploy_production.yml
@@ -12,11 +12,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
         with:
           python-version: '3.9'
 
-      - name: Set new project
+      - name: Generate new project
         run: make run PACKAGE_NAME=co.nimblehq.flutter.template PROJECT_NAME=flutter_templates APP_NAME="Flutter Templates"
 
       - name: Setup Java JDK

--- a/.github/workflows/android_deploy_staging.yml
+++ b/.github/workflows/android_deploy_staging.yml
@@ -13,11 +13,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
         with:
           python-version: '3.9'
 
-      - name: Set new project
+      - name: Generate new project
         run: make run PACKAGE_NAME=co.nimblehq.flutter.template PROJECT_NAME=flutter_templates APP_NAME="Flutter Templates"
 
       - name: Setup Java JDK

--- a/.github/workflows/android_deploy_staging.yml
+++ b/.github/workflows/android_deploy_staging.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - feature/47-setup-cd-to-build-and-deploy-android-app-to-firebase
 
 jobs:
   build_and_deploy_android:

--- a/.github/workflows/android_deploy_staging.yml
+++ b/.github/workflows/android_deploy_staging.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Deploy Android Staging to Firebase
         uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
         with:
-          appId: ${{secrets.FIREBASE_ANDROID_APP_ID_STAGING}}
-          serviceCredentialsFileContent: ${{secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON}}
+          appId: ${{ secrets.FIREBASE_ANDROID_APP_ID_STAGING }}
+          serviceCredentialsFileContent: ${{ secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON }}
           groups: nimble
           file: build/app/outputs/flutter-apk/app-staging-debug.apk

--- a/.github/workflows/android_deploy_staging.yml
+++ b/.github/workflows/android_deploy_staging.yml
@@ -49,10 +49,10 @@ jobs:
       - name: Build Android apk
         run: flutter build apk --flavor staging --debug --build-number $GITHUB_RUN_NUMBER
 
-      - name: Upload Android Staging to Firebase
-        uses: wzieba/Firebase-Distribution-Github-Action@v1.3.3
+      - name: Deploy Android Staging to Firebase
+        uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
         with:
           appId: ${{secrets.FIREBASE_ANDROID_APP_ID_STAGING}}
-          token: ${{secrets.FIREBASE_TOKEN}}
-          groups: dev
+          serviceCredentialsFileContent: ${{secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON}}
+          groups: nimble
           file: build/app/outputs/flutter-apk/app-staging-debug.apk

--- a/.github/workflows/android_deploy_staging.yml
+++ b/.github/workflows/android_deploy_staging.yml
@@ -1,0 +1,58 @@
+name: Android - Deploy Staging build to Firebase
+
+on:
+  push:
+    branches:
+      - develop
+      - feature/47-setup-cd-to-build-and-deploy-android-app-to-firebase
+
+jobs:
+  build_and_deploy_android:
+    name: Build & Deploy Android
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Set new project
+        run: make run PACKAGE_NAME=co.nimblehq.flutter.template PROJECT_NAME=flutter_templates APP_NAME="Flutter Templates"
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - name: Setup Flutter environment
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          flutter-version: '3.3.10'
+
+      - name: Get flutter dependencies
+        run: flutter pub get
+
+      - name: Run code generator.
+        run: flutter packages pub run build_runner build --delete-conflicting-outputs
+
+      - name: Setup .env.staging
+        env:
+          ENV_STAGING: ${{ secrets.ENV_STAGING }}
+        run: |
+          echo $ENV_STAGING > .env.staging
+
+      # App Bundle requires Firebase connected to Play Store to upload https://appdistribution.page.link/KPoa
+      - name: Build Android apk
+        run: flutter build apk --flavor staging --debug --build-number $GITHUB_RUN_NUMBER
+
+      - name: Upload Android Staging to Firebase
+        uses: wzieba/Firebase-Distribution-Github-Action@v1.3.3
+        with:
+          appId: ${{secrets.FIREBASE_ANDROID_APP_ID_STAGING}}
+          token: ${{secrets.FIREBASE_TOKEN}}
+          groups: dev
+          file: build/app/outputs/flutter-apk/app-staging-debug.apk

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -17,10 +17,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set new version
         id: set_version
         run: |
           perl -i -pe 's/^(version:\s+\d+\.\d+\.\d+\+)(\d+)$/"version: ${{ github.event.inputs.newVersion }}+".($2+1)/e' ./template/pubspec.yaml
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,16 +17,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.2
 
-      - uses: actions/setup-python@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
         with:
           python-version: '3.9'
 
-      - name: Set new project
+      - name: Generate new project
         run: make run PACKAGE_NAME=co.nimblehq.flutter.template PROJECT_NAME=flutter_templates APP_NAME="Flutter Templates"
 
-      - uses: subosito/flutter-action@v1
+      - name: Setup Flutter environment
+        uses: subosito/flutter-action@v2
         with:
-          channel: 'stable' # 'dev', 'alpha', default to: 'stable'
+          channel: 'stable'
           flutter-version: '3.3.10'
 
       - name: Get flutter dependencies.

--- a/template/.github/workflows/android_deploy_production.yml
+++ b/template/.github/workflows/android_deploy_production.yml
@@ -1,0 +1,49 @@
+name: Android - Deploy Production build to Firebase
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build_and_deploy_android:
+    name: Build & Deploy Android
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - name: Setup Flutter environment
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          flutter-version: '3.3.10'
+
+      - name: Get flutter dependencies
+        run: flutter pub get
+
+      - name: Run code generator.
+        run: flutter packages pub run build_runner build --delete-conflicting-outputs
+
+      - name: Setup .env
+        env:
+          ENV_PRODUCTION: ${{ secrets.ENV_PRODUCTION }}
+        run: |
+          echo $ENV_PRODUCTION > .env
+
+      # App Bundle requires Firebase connected to Play Store to upload https://appdistribution.page.link/KPoa
+      - name: Build Android apk
+        run: flutter build apk --flavor production --debug --build-number $GITHUB_RUN_NUMBER
+
+      - name: Deploy Android Production to Firebase
+        uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
+        with:
+          appId: ${{secrets.FIREBASE_ANDROID_APP_ID_PRODUCTION}}
+          serviceCredentialsFileContent: ${{secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON}}
+          groups: nimble
+          file: build/app/outputs/flutter-apk/app-production-debug.apk

--- a/template/.github/workflows/android_deploy_production.yml
+++ b/template/.github/workflows/android_deploy_production.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Deploy Android Production to Firebase
         uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
         with:
-          appId: ${{secrets.FIREBASE_ANDROID_APP_ID_PRODUCTION}}
-          serviceCredentialsFileContent: ${{secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON}}
+          appId: ${{ secrets.FIREBASE_ANDROID_APP_ID_PRODUCTION }}
+          serviceCredentialsFileContent: ${{ secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON }}
           groups: nimble
           file: build/app/outputs/flutter-apk/app-production-debug.apk

--- a/template/.github/workflows/android_deploy_staging.yml
+++ b/template/.github/workflows/android_deploy_staging.yml
@@ -1,0 +1,50 @@
+name: Android - Deploy Staging build to Firebase
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build_and_deploy_android:
+    name: Build & Deploy Android
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - name: Setup Flutter environment
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          flutter-version: '3.3.10'
+
+      - name: Get flutter dependencies
+        run: flutter pub get
+
+      - name: Run code generator.
+        run: flutter packages pub run build_runner build --delete-conflicting-outputs
+
+      - name: Setup .env.staging
+        env:
+          ENV_STAGING: ${{ secrets.ENV_STAGING }}
+        run: |
+          echo $ENV_STAGING > .env.staging
+
+      # App Bundle requires Firebase connected to Play Store to upload https://appdistribution.page.link/KPoa
+      - name: Build Android apk
+        run: flutter build apk --flavor staging --debug --build-number $GITHUB_RUN_NUMBER
+
+      - name: Upload Android Staging to Firebase
+        uses: wzieba/Firebase-Distribution-Github-Action@v1.3.3
+        with:
+          appId: ${{secrets.FIREBASE_ANDROID_APP_ID_STAGING}}
+          token: ${{secrets.FIREBASE_TOKEN}}
+          groups: dev
+          file: build/app/outputs/flutter-apk/app-staging-debug.apk

--- a/template/.github/workflows/android_deploy_staging.yml
+++ b/template/.github/workflows/android_deploy_staging.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Deploy Android Staging to Firebase
         uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
         with:
-          appId: ${{secrets.FIREBASE_ANDROID_APP_ID_STAGING}}
-          serviceCredentialsFileContent: ${{secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON}}
+          appId: ${{ secrets.FIREBASE_ANDROID_APP_ID_STAGING }}
+          serviceCredentialsFileContent: ${{ secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON }}
           groups: nimble
           file: build/app/outputs/flutter-apk/app-staging-debug.apk

--- a/template/.github/workflows/android_deploy_staging.yml
+++ b/template/.github/workflows/android_deploy_staging.yml
@@ -9,7 +9,6 @@ jobs:
   build_and_deploy_android:
     name: Build & Deploy Android
     runs-on: ubuntu-latest
-    environment: staging
     steps:
       - uses: actions/checkout@v3
 
@@ -41,10 +40,10 @@ jobs:
       - name: Build Android apk
         run: flutter build apk --flavor staging --debug --build-number $GITHUB_RUN_NUMBER
 
-      - name: Upload Android Staging to Firebase
-        uses: wzieba/Firebase-Distribution-Github-Action@v1.3.3
+      - name: Deploy Android Staging to Firebase
+        uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
         with:
           appId: ${{secrets.FIREBASE_ANDROID_APP_ID_STAGING}}
-          token: ${{secrets.FIREBASE_TOKEN}}
-          groups: dev
+          serviceCredentialsFileContent: ${{secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON}}
+          groups: nimble
           file: build/app/outputs/flutter-apk/app-staging-debug.apk

--- a/template/.github/workflows/ios_deploy_to_app_store.yml
+++ b/template/.github/workflows/ios_deploy_to_app_store.yml
@@ -28,10 +28,11 @@ jobs:
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-    - uses: subosito/flutter-action@v1
+    - name: Setup Flutter environment
+      uses: subosito/flutter-action@v2
       with:
         channel: 'stable'
-        flutter-version: '2.10.3'
+        flutter-version: '3.3.10'
 
     - name: Get flutter dependencies
       run: flutter pub get

--- a/template/.github/workflows/ios_deploy_to_testflight.yml
+++ b/template/.github/workflows/ios_deploy_to_testflight.yml
@@ -25,10 +25,11 @@ jobs:
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-    - uses: subosito/flutter-action@v1
+    - name: Setup Flutter environment
+      uses: subosito/flutter-action@v2
       with:
         channel: 'stable'
-        flutter-version: '2.10.3'
+        flutter-version: '3.3.10'
 
     - name: Get flutter dependencies
       run: flutter pub get

--- a/template/.github/workflows/test.yml
+++ b/template/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.2
 
-      # Setup the flutter environment.
-      - uses: subosito/flutter-action@v1
+      - name: Setup Flutter environment
+        uses: subosito/flutter-action@v2
         with:
-          channel: 'stable' # 'dev', 'alpha', default to: 'stable'
+          channel: 'stable'
           flutter-version: '3.3.10'
 
       - name: Get flutter dependencies.
@@ -37,9 +37,9 @@ jobs:
       - name: Run widget tests, unit tests.
         run: flutter test --machine --coverage
 
-      - uses: codecov/codecov-action@v2
+      - name: Upload coverage to codecov 
+        uses: codecov/codecov-action@v2
         with:
-          name: Upload coverage to codecov
           files: ./coverage/lcov.info
           flags: unittests # optional
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos


### PR DESCRIPTION
- Solves #47

## What happened 👀

- Add 2 new workflows to build & deploy Android `Staging` & `Production` builds to Firebase App Distribution.
- Firebase apps for the Flutter Templates project: https://console.firebase.google.com/u/1/project/fluttertempates---staging/overview.
- Refactor: Add missing names to some Action steps in existing workflows.

## Insight 📝

- There are 2 workflow versions for each:
  - `template` project's workflow 👉 for the generated project.
  - root project's workflow (the mirrored workflow) 👉 to test the workflow on generated project & deploy the generated Flutter Templates for reference.
- To distribute apps to Firebase, we need to create & use a [`Service Account`](https://console.cloud.google.com/iam-admin/serviceaccounts?authuser=0&project=fluttertempates---staging) instead of the deprecated `FIREBASE_TOKEN`. More info [here](https://github.com/wzieba/Firebase-Distribution-Github-Action/wiki/FIREBASE_TOKEN-migration).

## Proof Of Work 📹

- Staging build on Firebase: https://github.com/nimblehq/flutter_templates/actions/runs/4295932644/jobs/7487015849

<img width="1188" alt="image" src="https://user-images.githubusercontent.com/16315358/221943883-069fad2d-c7ac-4fc6-b40d-a61ec88ec2db.png">


- Production build on Firebase: https://github.com/nimblehq/flutter_templates/actions/runs/4296113779/jobs/7487428336

<img width="1185" alt="image" src="https://user-images.githubusercontent.com/16315358/221945993-a4a9cfba-3975-4718-a063-ca720d6482f6.png">
