### PR TITLE
[#61] As a developer, I can have a CD process to build and deploy the Android app to Play Store

### DIFF
--- a/.github/wiki/Deployment.md
+++ b/.github/wiki/Deployment.md
@@ -30,7 +30,7 @@
     - The access to Git’s [Match repository](https://codesigning.guide/).
 
 - Create certificates for distribution and [code signing](https://codesigning.guide/) so we are able to fetch the certificates through the [Match](https://docs.fastlane.tools/actions/match/) repository.
-- Setup [Fastlane](https://docs.fastlane.tools/getting-started/ios/setup/) and [Match](https://docs.fastlane.tools/actions/match/).
+- Set up [Fastlane](https://docs.fastlane.tools/getting-started/ios/setup/) and [Match](https://docs.fastlane.tools/actions/match/).
 - Add these variables as the secrets of CI:
 
     - **FASTLANE_USER**: This will be referred to in `Appfile` and `Fastfile`. Set your Apple ID to this variable.

--- a/.github/wiki/Deployment.md
+++ b/.github/wiki/Deployment.md
@@ -1,19 +1,37 @@
 # Deployment Process
 
+## For Android
+
+### Guide
+
+- Before publishing the Android application, we have to prepare the necessary credentials and information:
+  - A Play Store developer account.
+  - Your application's app id. This could be multiple bundle ids according to the number of application’s flavors.
+  - A new app on Play Store.
+
+- Add these variables as the secrets of CI:
+  - **ENV_PRODUCTION**: the production .env configuration file content.
+  - **GOOGLE_PLAY_SERVICE_ACCOUNT_JSON**: the json file content of the Play Store's Service Account for app publishing. Please check out [how to create the Service Account](https://support.staffbase.com/hc/en-us/articles/360018569579-Preparing-Automated-Publishing-for-Google-Play-Store).
+
+### Resources
+
+- [Build and release an Android app](https://docs.flutter.dev/deployment/android#build-an-apk).
+- [Preparing Automated Publishing for Google Play Store](https://support.staffbase.com/hc/en-us/articles/360018569579-Preparing-Automated-Publishing-for-Google-Play-Store).
+
 ## For iOS
 
 ### Guide
 
-- Before deploying the iOS application, we have to prepare the necessary credentials and information:
+- Before publishing the iOS application, we have to prepare the necessary credentials and information:
 
     - An Apple developer account.
     - Your application’s bundle id. This could be multiple bundle ids according to the number of application’s flavors.
-    - A new app's on Apple Store Connect that links to the bundle id.
+    - A new app on Apple Store Connect that links to the bundle id.
     - The access to Git’s [Match repository](https://codesigning.guide/).
 
-- Create certificates for distribution and [code signing](https://codesigning.guide/) so we are able to fetch the certificates through [Match](https://docs.fastlane.tools/actions/match/).
+- Create certificates for distribution and [code signing](https://codesigning.guide/) so we are able to fetch the certificates through the [Match](https://docs.fastlane.tools/actions/match/) repository.
 - Setup [Fastlane](https://docs.fastlane.tools/getting-started/ios/setup/) and [Match](https://docs.fastlane.tools/actions/match/).
-- Adding these variables as the environment variable of CI:
+- Add these variables as the secrets of CI:
 
     - **FASTLANE_USER**: This will be referred to in `Appfile` and `Fastfile`. Set your Apple ID to this variable.
     - **FASTLANE_PASSWORD**: This variable will be referred to internally in Fastlane. Set the password of your Apple ID to this variable.
@@ -23,9 +41,9 @@
     - **KEYCHAIN_PASSWORD**: We can create a keychain password for ourself and it could be anything.
     - **SSH_PRIVATE_KEY**: In order to fetch the distribution files from Git’s [Match repository](https://codesigning.guide/), we have to generate an SSH key and save it as the environment variable in CI.
   
-- Run the corresponding workflows CI or `fastlane` commands and enjoy the result!
+- Run the corresponding workflows or `fastlane` commands and enjoy the result!
 
-### Resource
+### Resources
 
 - [https://medium.com/flutter-community/deploying-flutter-ios-apps-with-fastlane-and-github-actions-2e87465e056e](https://medium.com/flutter-community/deploying-flutter-ios-apps-with-fastlane-and-github-actions-2e87465e056e)
 - [https://docs.flutter.dev/deployment/cd](https://docs.flutter.dev/deployment/cd)

--- a/.github/workflows/android_deploy_production.yml
+++ b/.github/workflows/android_deploy_production.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Python
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: '3.9'
@@ -22,13 +22,13 @@ jobs:
       - name: Generate new project
         run: make run PACKAGE_NAME=co.nimblehq.flutter.template PROJECT_NAME=flutter_templates APP_NAME="Flutter Templates"
 
-      - name: Setup Java JDK
+      - name: Set up Java JDK
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
           java-version: '11'
 
-      - name: Setup Flutter environment
+      - name: Set up Flutter environment
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
@@ -40,7 +40,7 @@ jobs:
       - name: Run code generator.
         run: flutter packages pub run build_runner build --delete-conflicting-outputs
 
-      - name: Setup .env
+      - name: Set up .env
         env:
           ENV_PRODUCTION: ${{ secrets.ENV_PRODUCTION }}
         run: |

--- a/.github/workflows/android_deploy_production.yml
+++ b/.github/workflows/android_deploy_production.yml
@@ -9,6 +9,7 @@ jobs:
   build_and_deploy_android:
     name: Build & Deploy Android
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/android_deploy_production.yml
+++ b/.github/workflows/android_deploy_production.yml
@@ -34,10 +34,10 @@ jobs:
           channel: 'stable'
           flutter-version: '3.3.10'
 
-      - name: Get flutter dependencies
+      - name: Get Flutter dependencies
         run: flutter pub get
 
-      - name: Run code generator.
+      - name: Run code generator
         run: flutter packages pub run build_runner build --delete-conflicting-outputs
 
       - name: Set up .env

--- a/.github/workflows/android_deploy_production.yml
+++ b/.github/workflows/android_deploy_production.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/android_deploy_production_to_playstore.yml
+++ b/.github/workflows/android_deploy_production_to_playstore.yml
@@ -55,5 +55,5 @@ jobs:
           packageName: co.nimblehq.flutter.template
           releaseFile: build/app/outputs/bundle/productionRelease/app-production-release.aab
           track: internal
-          userFraction: 0.0
+          userFraction: 1.0
           whatsNewDirectory: .github/workflows/whatsnew

--- a/.github/workflows/android_deploy_production_to_playstore.yml
+++ b/.github/workflows/android_deploy_production_to_playstore.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Python
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: '3.9'
@@ -22,13 +22,13 @@ jobs:
       - name: Generate new project
         run: make run PACKAGE_NAME=co.nimblehq.flutter.template PROJECT_NAME=flutter_templates APP_NAME="Flutter Templates"
 
-      - name: Setup Java JDK
+      - name: Set up Java JDK
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
           java-version: '11'
 
-      - name: Setup Flutter environment
+      - name: Set up Flutter environment
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
@@ -40,7 +40,7 @@ jobs:
       - name: Run code generator.
         run: flutter packages pub run build_runner build --delete-conflicting-outputs
 
-      - name: Setup .env
+      - name: Set up .env
         env:
           ENV_PRODUCTION: ${{ secrets.ENV_PRODUCTION }}
         run: |

--- a/.github/workflows/android_deploy_production_to_playstore.yml
+++ b/.github/workflows/android_deploy_production_to_playstore.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feature/61-setup-cd-to-build-and-deploy-android-app-to-playstore
 
 jobs:
   build_and_deploy_android:

--- a/.github/workflows/android_deploy_production_to_playstore.yml
+++ b/.github/workflows/android_deploy_production_to_playstore.yml
@@ -9,6 +9,7 @@ jobs:
   build_and_deploy_android:
     name: Build & Deploy Android
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/android_deploy_production_to_playstore.yml
+++ b/.github/workflows/android_deploy_production_to_playstore.yml
@@ -1,0 +1,59 @@
+name: Android - Deploy Production build to Play Store
+
+on:
+  push:
+    branches:
+      - main
+      - feature/61-setup-cd-to-build-and-deploy-android-app-to-playstore
+
+jobs:
+  build_and_deploy_android:
+    name: Build & Deploy Android
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Generate new project
+        run: make run PACKAGE_NAME=co.nimblehq.flutter.template PROJECT_NAME=flutter_templates APP_NAME="Flutter Templates"
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - name: Setup Flutter environment
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          flutter-version: '3.3.10'
+
+      - name: Get flutter dependencies
+        run: flutter pub get
+
+      - name: Run code generator.
+        run: flutter packages pub run build_runner build --delete-conflicting-outputs
+
+      - name: Setup .env
+        env:
+          ENV_PRODUCTION: ${{ secrets.ENV_PRODUCTION }}
+        run: |
+          echo $ENV_PRODUCTION > .env
+
+      - name: Build Production App Bundle
+        run: flutter build appbundle --flavor production --release --build-number $GITHUB_RUN_NUMBER
+
+      - name: Upload Android Production Release bundle to Play Store
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJson: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: co.nimblehq.flutter.template
+          releaseFile: build/app/outputs/bundle/productionRelease/app-production-release.aab
+          track: internal
+          userFraction: 0.0
+          whatsNewDirectory: .github/workflows/whatsnew

--- a/.github/workflows/android_deploy_production_to_playstore.yml
+++ b/.github/workflows/android_deploy_production_to_playstore.yml
@@ -48,12 +48,14 @@ jobs:
       - name: Build Production App Bundle
         run: flutter build appbundle --flavor production --release --build-number $GITHUB_RUN_NUMBER
 
-      - name: Upload Android Production Release bundle to Play Store
-        uses: r0adkll/upload-google-play@v1
-        with:
-          serviceAccountJson: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
-          packageName: co.nimblehq.flutter.template
-          releaseFile: build/app/outputs/bundle/productionRelease/app-production-release.aab
-          track: internal
-          userFraction: 1.0
-          whatsNewDirectory: .github/workflows/whatsnew
+      # TODO We will enable this step later when having a shared Service Account on our organization
+      # Basically, this step will work properly after providing a valid Service Account.
+      # - name: Upload Android Production Release bundle to Play Store
+      #   uses: r0adkll/upload-google-play@v1
+      #   with:
+      #     serviceAccountJson: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+      #     packageName: co.nimblehq.flutter.template
+      #     releaseFile: build/app/outputs/bundle/productionRelease/app-production-release.aab
+      #     track: internal
+      #     userFraction: 1.0
+      #     whatsNewDirectory: .github/workflows/whatsnew

--- a/.github/workflows/android_deploy_production_to_playstore.yml
+++ b/.github/workflows/android_deploy_production_to_playstore.yml
@@ -34,10 +34,10 @@ jobs:
           channel: 'stable'
           flutter-version: '3.3.10'
 
-      - name: Get flutter dependencies
+      - name: Get Flutter dependencies
         run: flutter pub get
 
-      - name: Run code generator.
+      - name: Run code generator
         run: flutter packages pub run build_runner build --delete-conflicting-outputs
 
       - name: Set up .env

--- a/.github/workflows/android_deploy_production_to_playstore.yml
+++ b/.github/workflows/android_deploy_production_to_playstore.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/android_deploy_staging.yml
+++ b/.github/workflows/android_deploy_staging.yml
@@ -12,7 +12,8 @@ jobs:
     timeout-minutes: 30
     environment: staging
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/android_deploy_staging.yml
+++ b/.github/workflows/android_deploy_staging.yml
@@ -9,6 +9,7 @@ jobs:
   build_and_deploy_android:
     name: Build & Deploy Android
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     environment: staging
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/android_deploy_staging.yml
+++ b/.github/workflows/android_deploy_staging.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Python
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: '3.9'
@@ -23,13 +23,13 @@ jobs:
       - name: Generate new project
         run: make run PACKAGE_NAME=co.nimblehq.flutter.template PROJECT_NAME=flutter_templates APP_NAME="Flutter Templates"
 
-      - name: Setup Java JDK
+      - name: Set up Java JDK
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
           java-version: '11'
 
-      - name: Setup Flutter environment
+      - name: Set up Flutter environment
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
@@ -41,7 +41,7 @@ jobs:
       - name: Run code generator.
         run: flutter packages pub run build_runner build --delete-conflicting-outputs
 
-      - name: Setup .env.staging
+      - name: Set up .env.staging
         env:
           ENV_STAGING: ${{ secrets.ENV_STAGING }}
         run: |

--- a/.github/workflows/android_deploy_staging.yml
+++ b/.github/workflows/android_deploy_staging.yml
@@ -35,10 +35,10 @@ jobs:
           channel: 'stable'
           flutter-version: '3.3.10'
 
-      - name: Get flutter dependencies
+      - name: Get Flutter dependencies
         run: flutter pub get
 
-      - name: Run code generator.
+      - name: Run code generator
         run: flutter packages pub run build_runner build --delete-conflicting-outputs
 
       - name: Set up .env.staging

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -12,6 +12,7 @@ jobs:
   bump_version:
     name: Bump version
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout the latest code
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
   test:
     name: Template initializing scripts test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2.3.2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.2
 
-      - name: Setup Python
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: '3.9'
@@ -26,7 +26,7 @@ jobs:
       - name: Generate new project
         run: make run PACKAGE_NAME=co.nimblehq.flutter.template PROJECT_NAME=flutter_templates APP_NAME="Flutter Templates"
 
-      - name: Setup Flutter environment
+      - name: Set up Flutter environment
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,17 +32,17 @@ jobs:
           channel: 'stable'
           flutter-version: '3.3.10'
 
-      - name: Get flutter dependencies.
+      - name: Get Flutter dependencies
         run: flutter pub get
 
       - name: Run code generator
         run: flutter packages pub run build_runner build --delete-conflicting-outputs
 
-      - name: Check for any formatting issues in the code.
+      - name: Check for any formatting issues in the code
         run: flutter format --set-exit-if-changed .
 
-      - name: Statically analyze the Dart code for any errors.
+      - name: Statically analyze the Dart code for any errors
         run: flutter analyze .
 
-      - name: Run widget tests, unit tests.
+      - name: Run widget tests, unit tests
         run: flutter test --machine --coverage

--- a/template/.github/workflows/android_deploy_production.yml
+++ b/template/.github/workflows/android_deploy_production.yml
@@ -9,6 +9,7 @@ jobs:
   build_and_deploy_android:
     name: Build & Deploy Android
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
 

--- a/template/.github/workflows/android_deploy_production.yml
+++ b/template/.github/workflows/android_deploy_production.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Setup Java JDK
         uses: actions/setup-java@v3

--- a/template/.github/workflows/android_deploy_production.yml
+++ b/template/.github/workflows/android_deploy_production.yml
@@ -14,13 +14,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Java JDK
+      - name: Set up Java JDK
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
           java-version: '11'
 
-      - name: Setup Flutter environment
+      - name: Set up Flutter environment
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
@@ -32,7 +32,7 @@ jobs:
       - name: Run code generator.
         run: flutter packages pub run build_runner build --delete-conflicting-outputs
 
-      - name: Setup .env
+      - name: Set up .env
         env:
           ENV_PRODUCTION: ${{ secrets.ENV_PRODUCTION }}
         run: |

--- a/template/.github/workflows/android_deploy_production.yml
+++ b/template/.github/workflows/android_deploy_production.yml
@@ -26,10 +26,10 @@ jobs:
           channel: 'stable'
           flutter-version: '3.3.10'
 
-      - name: Get flutter dependencies
+      - name: Get Flutter dependencies
         run: flutter pub get
 
-      - name: Run code generator.
+      - name: Run code generator
         run: flutter packages pub run build_runner build --delete-conflicting-outputs
 
       - name: Set up .env

--- a/template/.github/workflows/android_deploy_production_to_playstore.yml
+++ b/template/.github/workflows/android_deploy_production_to_playstore.yml
@@ -1,0 +1,50 @@
+name: Android - Deploy Production build to Play Store
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build_and_deploy_android:
+    name: Build & Deploy Android
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - name: Setup Flutter environment
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          flutter-version: '3.3.10'
+
+      - name: Get flutter dependencies
+        run: flutter pub get
+
+      - name: Run code generator.
+        run: flutter packages pub run build_runner build --delete-conflicting-outputs
+
+      - name: Setup .env
+        env:
+          ENV_PRODUCTION: ${{ secrets.ENV_PRODUCTION }}
+        run: |
+          echo $ENV_PRODUCTION > .env
+
+      - name: Build Production App Bundle
+        run: flutter build appbundle --flavor production --release --build-number $GITHUB_RUN_NUMBER
+
+      - name: Upload Android Production Release bundle to Play Store
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJson: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: co.nimblehq.flutter.template
+          releaseFile: build/app/outputs/bundle/productionRelease/app-production-release.aab
+          track: internal
+          userFraction: 0.0
+          whatsNewDirectory: .github/workflows/whatsnew

--- a/template/.github/workflows/android_deploy_production_to_playstore.yml
+++ b/template/.github/workflows/android_deploy_production_to_playstore.yml
@@ -9,6 +9,7 @@ jobs:
   build_and_deploy_android:
     name: Build & Deploy Android
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
 

--- a/template/.github/workflows/android_deploy_production_to_playstore.yml
+++ b/template/.github/workflows/android_deploy_production_to_playstore.yml
@@ -46,5 +46,5 @@ jobs:
           packageName: co.nimblehq.flutter.template
           releaseFile: build/app/outputs/bundle/productionRelease/app-production-release.aab
           track: internal
-          userFraction: 0.0
+          userFraction: 1.0
           whatsNewDirectory: .github/workflows/whatsnew

--- a/template/.github/workflows/android_deploy_production_to_playstore.yml
+++ b/template/.github/workflows/android_deploy_production_to_playstore.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Setup Java JDK
         uses: actions/setup-java@v3

--- a/template/.github/workflows/android_deploy_production_to_playstore.yml
+++ b/template/.github/workflows/android_deploy_production_to_playstore.yml
@@ -14,13 +14,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Java JDK
+      - name: Set up Java JDK
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
           java-version: '11'
 
-      - name: Setup Flutter environment
+      - name: Set up Flutter environment
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
@@ -32,7 +32,7 @@ jobs:
       - name: Run code generator.
         run: flutter packages pub run build_runner build --delete-conflicting-outputs
 
-      - name: Setup .env
+      - name: Set up .env
         env:
           ENV_PRODUCTION: ${{ secrets.ENV_PRODUCTION }}
         run: |

--- a/template/.github/workflows/android_deploy_production_to_playstore.yml
+++ b/template/.github/workflows/android_deploy_production_to_playstore.yml
@@ -26,10 +26,10 @@ jobs:
           channel: 'stable'
           flutter-version: '3.3.10'
 
-      - name: Get flutter dependencies
+      - name: Get Flutter dependencies
         run: flutter pub get
 
-      - name: Run code generator.
+      - name: Run code generator
         run: flutter packages pub run build_runner build --delete-conflicting-outputs
 
       - name: Set up .env

--- a/template/.github/workflows/android_deploy_staging.yml
+++ b/template/.github/workflows/android_deploy_staging.yml
@@ -9,6 +9,7 @@ jobs:
   build_and_deploy_android:
     name: Build & Deploy Android
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
 

--- a/template/.github/workflows/android_deploy_staging.yml
+++ b/template/.github/workflows/android_deploy_staging.yml
@@ -26,10 +26,10 @@ jobs:
           channel: 'stable'
           flutter-version: '3.3.10'
 
-      - name: Get flutter dependencies
+      - name: Get Flutter dependencies
         run: flutter pub get
 
-      - name: Run code generator.
+      - name: Run code generator
         run: flutter packages pub run build_runner build --delete-conflicting-outputs
 
       - name: Set up .env.staging

--- a/template/.github/workflows/android_deploy_staging.yml
+++ b/template/.github/workflows/android_deploy_staging.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Setup Java JDK
         uses: actions/setup-java@v3

--- a/template/.github/workflows/android_deploy_staging.yml
+++ b/template/.github/workflows/android_deploy_staging.yml
@@ -14,13 +14,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Java JDK
+      - name: Set up Java JDK
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
           java-version: '11'
 
-      - name: Setup Flutter environment
+      - name: Set up Flutter environment
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
@@ -32,7 +32,7 @@ jobs:
       - name: Run code generator.
         run: flutter packages pub run build_runner build --delete-conflicting-outputs
 
-      - name: Setup .env.staging
+      - name: Set up .env.staging
         env:
           ENV_STAGING: ${{ secrets.ENV_STAGING }}
         run: |

--- a/template/.github/workflows/bump_version.yml
+++ b/template/.github/workflows/bump_version.yml
@@ -12,6 +12,7 @@ jobs:
   bump_version:
     name: Bump version
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout the latest code
         uses: actions/checkout@v3

--- a/template/.github/workflows/ios_deploy_to_app_store.yml
+++ b/template/.github/workflows/ios_deploy_to_app_store.yml
@@ -9,6 +9,7 @@ jobs:
   build_and_upload_to_app_store:
     name: Build And Upload iOS Application To AppStore
     runs-on: macOS-latest
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: template

--- a/template/.github/workflows/ios_deploy_to_app_store.yml
+++ b/template/.github/workflows/ios_deploy_to_app_store.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-    - name: Setup Flutter environment
+    - name: Set up Flutter environment
       uses: subosito/flutter-action@v2
       with:
         channel: 'stable'

--- a/template/.github/workflows/ios_deploy_to_app_store.yml
+++ b/template/.github/workflows/ios_deploy_to_app_store.yml
@@ -35,7 +35,7 @@ jobs:
         channel: 'stable'
         flutter-version: '3.3.10'
 
-    - name: Get flutter dependencies
+    - name: Get Flutter dependencies
       run: flutter pub get
 
     - name: Run code generator

--- a/template/.github/workflows/ios_deploy_to_testflight.yml
+++ b/template/.github/workflows/ios_deploy_to_testflight.yml
@@ -9,6 +9,7 @@ jobs:
   build_and_upload_to_testflight:
     name: Build And Upload iOS Application To TestFlight
     runs-on: macOS-latest
+    timeout-minutes: 30
     env:
       TEAM_ID: ${{ secrets.TEAM_ID }}
       FASTLANE_USER: ${{ secrets.FASTLANE_USER }}

--- a/template/.github/workflows/ios_deploy_to_testflight.yml
+++ b/template/.github/workflows/ios_deploy_to_testflight.yml
@@ -32,7 +32,7 @@ jobs:
         channel: 'stable'
         flutter-version: '3.3.10'
 
-    - name: Get flutter dependencies
+    - name: Get Flutter dependencies
       run: flutter pub get
 
     - name: Run code generator

--- a/template/.github/workflows/ios_deploy_to_testflight.yml
+++ b/template/.github/workflows/ios_deploy_to_testflight.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-    - name: Setup Flutter environment
+    - name: Set up Flutter environment
       uses: subosito/flutter-action@v2
       with:
         channel: 'stable'

--- a/template/.github/workflows/test.yml
+++ b/template/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
   lint_and_test:
     name: Static code analyze & Unit test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     environment: staging
     steps:
       - uses: actions/checkout@v2.3.2

--- a/template/.github/workflows/test.yml
+++ b/template/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.2
 
-      - name: Setup Flutter environment
+      - name: Set up Flutter environment
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'

--- a/template/.github/workflows/test.yml
+++ b/template/.github/workflows/test.yml
@@ -23,19 +23,19 @@ jobs:
           channel: 'stable'
           flutter-version: '3.3.10'
 
-      - name: Get flutter dependencies.
+      - name: Get Flutter dependencies
         run: flutter pub get
 
       - name: Run code generator
         run: flutter packages pub run build_runner build --delete-conflicting-outputs
 
-      - name: Check for any formatting issues in the code.
+      - name: Check for any formatting issues in the code
         run: flutter format --set-exit-if-changed .
 
-      - name: Statically analyze the Dart code for any errors.
+      - name: Statically analyze the Dart code for any errors
         run: flutter analyze .
 
-      - name: Run widget tests, unit tests.
+      - name: Run widget tests, unit tests
         run: flutter test --machine --coverage
 
       - name: Upload coverage to codecov 

--- a/template/.github/workflows/whatsnew/whatsnew-en-US
+++ b/template/.github/workflows/whatsnew/whatsnew-en-US
@@ -1,0 +1,3 @@
+<en-US>
+Enter or paste your release notes for en-US here
+</en-US>


### PR DESCRIPTION
- Solves #61

## What happened 👀

- Add a new workflow to build & deploy the Android `Production` release AppBundle to Play Store.
- Firebase apps for the Flutter Templates project: https://console.firebase.google.com/u/1/project/fluttertempates---staging/overview.
- Add wiki for the Android app publishing.

## Insight 📝

- There are 2 workflow versions for each:
  - `template` project's workflow 👉 for the generated project.
  - root project's workflow (the mirrored workflow) 👉 to test the workflow on generated project & deploy the generated Flutter Templates for reference.
- Use [`flutter build appbundle`](https://docs.flutter.dev/deployment/android#build-an-app-bundle) to build AppBundle for Play Store publishing.
- To upload the build to Play Store, we need to create & use a [`Service Account`](https://console.cloud.google.com/iam-admin/serviceaccounts?authuser=0&project=fluttertempates---staging).

## Proof Of Work 📹

- 🚧 We're disabling the final step: `uploading the bundle to Play Store` while [waiting for a shared Play Store Service Account](https://nimble-co.slack.com/archives/CFSQY8VK4/p1677646814091149) for app publishing 🚧.
- The final step would work properly after providing a valid Service Account.
- The rest of the preparation is passed ✅  https://github.com/nimblehq/flutter_templates/actions/runs/4351489256/jobs/7603198451.
