### PR TITLE
[#172] Rename repository name to "flutter-templates"

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,8 +4,8 @@ contact_links:
   - name: Request For Comments (RFC)
     about: When having an idea on how to improve our processes, propose the idea so that the team can provide feedback.
     # URL to create an RFC with the template
-    url: https://github.com/nimblehq/flutter_templates/discussions/new?category=rfcs&title=+&body=%23%23+Issue%0D%0A%0D%0ADescribe+the+issue+the+team+is+currently+facing.+Provide+as+much+content+as+possible.%0D%0A%0D%0A%23%23+Solution%0D%0A%0D%0ADescribe+the+solution+you+are+prescribing+for+the+issue%0D%0A%0D%0A%23%23+Who+Benefits%3F%0D%0A%0D%0ADescribe+who+will+be+the+beneficiaries+e.g.+everyone,+specific+chapters,+clients...%0D%0A%0D%0A%23%23+What%27s+Next%3F%0D%0A%0D%0AProvide+an+actionable+list+of+things+that+must+happen+in+order+to+implement+the+solution:%0D%0A%0D%0A-+[+]%0D%0A-+[+]%0D%0A-+[+]
+    url: https://github.com/nimblehq/flutter-templates/discussions/new?category=rfcs&title=+&body=%23%23+Issue%0D%0A%0D%0ADescribe+the+issue+the+team+is+currently+facing.+Provide+as+much+content+as+possible.%0D%0A%0D%0A%23%23+Solution%0D%0A%0D%0ADescribe+the+solution+you+are+prescribing+for+the+issue%0D%0A%0D%0A%23%23+Who+Benefits%3F%0D%0A%0D%0ADescribe+who+will+be+the+beneficiaries+e.g.+everyone,+specific+chapters,+clients...%0D%0A%0D%0A%23%23+What%27s+Next%3F%0D%0A%0D%0AProvide+an+actionable+list+of+things+that+must+happen+in+order+to+implement+the+solution:%0D%0A%0D%0A-+[+]%0D%0A-+[+]%0D%0A-+[+]
 
   - name: Ask a question
     about: When having a question about a pull request, issue, or problem, create a Q&A discussion to get help from the team.
-    url: https://github.com/nimblehq/flutter_templates/discussions/new?category=q-a
+    url: https://github.com/nimblehq/flutter-templates/discussions/new?category=q-a

--- a/.github/PULL_REQUEST_TEMPLATE/release_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_template.md
@@ -1,4 +1,4 @@
-https://github.com/nimblehq/flutter_templates/milestone/?
+https://github.com/nimblehq/flutter-templates/milestone/?
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Clone the repository
 
 `git clone git@github.com:nimblehq/flutter-templates.git`
 
+## Documentation
+
+Checkout the [Wiki](https://github.com/nimblehq/flutter-templates/wiki) page to access the full documentation.
+
 ## Use the template
 
 ### Setup a new project

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ All the templates that can be used to kick off a new Flutter application quickly
 
 Clone the repository
 
-`git clone git@github.com:nimblehq/flutter_templates.git`
+`git clone git@github.com:nimblehq/flutter-templates.git`
 
 ## Use the template
 
@@ -28,7 +28,7 @@ Clone the repository
   | PROJECT_NAME   |     Yes      | The application project name. The naming convention follows `your_project_name` |
   | APP_NAME       |     Yes      | The application name.                                                           |
 
-  More available configs [here](https://github.com/nimblehq/flutter_templates/wiki/Generating-A-Project)
+  More available configs [here](https://github.com/nimblehq/flutter-templates/wiki/Generating-A-Project)
 
 - For more supporting commands, run:
 

--- a/template/.github/PULL_REQUEST_TEMPLATE.md
+++ b/template/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-https://github.com/nimblehq/flutter_templates/issues/??
+https://github.com/nimblehq/flutter-templates/issues/??
 
 ## What happened 👀
 

--- a/template/.github/PULL_REQUEST_TEMPLATE/release_template.md
+++ b/template/.github/PULL_REQUEST_TEMPLATE/release_template.md
@@ -1,4 +1,4 @@
-Link to the milestone on Github e.g. https://github.com/nimblehq/flutter_templates/milestone/41?closed=1
+Link to the milestone on Github e.g. https://github.com/nimblehq/flutter-templates/milestone/41?closed=1
 or Link to the project management tool for the release
 
 ## Features
@@ -6,7 +6,7 @@ or Link to the project management tool for the release
 Provide the ID and title of the issue in the section for each type (feature, chore and bug). The link is optional.
 
 - [#1] As a user, I can log in or
-- [[#1](https://github.com/nimblehq/flutter_templates/issues/1)] As a user, I can log in
+- [[#1](https://github.com/nimblehq/flutter-templates/issues/1)] As a user, I can log in
 
 ## Chores
 - Same structure as in  ## Feature

--- a/template/README.md
+++ b/template/README.md
@@ -1,6 +1,6 @@
 # Flutter Templates
 
-[![codecov](https://codecov.io/gh/nimblehq/flutter_templates/branch/main/graph/badge.svg?token=ATUNXDX218)](https://codecov.io/gh/nimblehq/flutter_templates)
+[![codecov](https://codecov.io/gh/nimblehq/flutter-templates/branch/main/graph/badge.svg?token=ATUNXDX218)](https://codecov.io/gh/nimblehq/flutter-templates)
 
 All the templates that can be used to kick off a new Flutter application quickly.
 
@@ -8,7 +8,7 @@ All the templates that can be used to kick off a new Flutter application quickly
 
 Clone the repository
 
-`git clone git@github.com:nimblehq/flutter_templates.git`
+`git clone git@github.com:nimblehq/flutter-templates.git`
 
 ## Prerequisite
 


### PR DESCRIPTION
- Solves #172

## What happened 👀

- Rename repository name to flutter-templates.
- Update README & wiki to follow the new name.
- Add `Wiki` link in the root README.

## Insight 📝

- I tried to find all related strings in the repository related to the repository name and renamed them to `flutter-templates`.
- The rest of `flutter_templates` belongs to the `template` project name & imports. We need to keep using `flutter_templates`.

![image](https://user-images.githubusercontent.com/16315358/223989424-8a15dcaf-fafa-454a-997f-f9e149f1193d.png)


## Proof Of Work 📹

New repo name: https://github.com/nimblehq/flutter-templates ✅ 
The template is being generated properly & the generated app is buildable & testable https://github.com/nimblehq/flutter-templates/actions/runs/4373243729/jobs/7651168442 ✅ 

