### PR TITLE
[#157] [Generate project with Mason] Migrate iOS project module generating step

### DIFF
--- a/bricks/template/__brick__/template/ios/Runner.xcodeproj/project.pbxproj
+++ b/bricks/template/__brick__/template/ios/Runner.xcodeproj/project.pbxproj
@@ -364,7 +364,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
-				APP_DISPLAY_NAME = "Flutter Templates";
+				APP_DISPLAY_NAME = "{{app_name.titleCase()}}";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
@@ -376,9 +376,9 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = co.nimblehq.flutter.template.staging;
+				PRODUCT_BUNDLE_IDENTIFIER = {{package_name.dotCase()}}.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc co.nimblehq.flutter.template.staging";
+				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc {{package_name.dotCase()}}.staging";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -496,7 +496,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
-				APP_DISPLAY_NAME = "Flutter Templates";
+				APP_DISPLAY_NAME = "{{app_name.titleCase()}}";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
@@ -508,9 +508,9 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = co.nimblehq.flutter.template.staging;
+				PRODUCT_BUNDLE_IDENTIFIER = {{package_name.dotCase()}}.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc co.nimblehq.flutter.template.staging";
+				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc {{package_name.dotCase()}}.staging";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -522,7 +522,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
-				APP_DISPLAY_NAME = "Flutter Templates";
+				APP_DISPLAY_NAME = "{{app_name.titleCase()}}";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
@@ -536,9 +536,9 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = co.nimblehq.flutter.template.staging;
+				PRODUCT_BUNDLE_IDENTIFIER = {{package_name.dotCase()}}.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc co.nimblehq.flutter.template.staging";
+				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc {{package_name.dotCase()}}.staging";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -604,7 +604,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
-				APP_DISPLAY_NAME = "Flutter Templates Staging";
+				APP_DISPLAY_NAME = "{{app_name.titleCase()}} Staging";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
@@ -616,9 +616,9 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = co.nimblehq.flutter.template.staging;
+				PRODUCT_BUNDLE_IDENTIFIER = {{package_name.dotCase()}}.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc co.nimblehq.flutter.template.staging";
+				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc {{package_name.dotCase()}}.staging";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -685,7 +685,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
-				APP_DISPLAY_NAME = "Flutter Templates Production";
+				APP_DISPLAY_NAME = "{{app_name.titleCase()}} Production";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
@@ -698,9 +698,9 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = co.nimblehq.flutter.template;
+				PRODUCT_BUNDLE_IDENTIFIER = {{package_name.dotCase()}};
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore co.nimblehq.flutter.template";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore {{package_name.dotCase()}}";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -764,7 +764,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
-				APP_DISPLAY_NAME = "Flutter Templates Staging";
+				APP_DISPLAY_NAME = "{{app_name.titleCase()}} Staging";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
@@ -777,9 +777,9 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = co.nimblehq.flutter.template.staging;
+				PRODUCT_BUNDLE_IDENTIFIER = {{package_name.dotCase()}}.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore co.nimblehq.flutter.template.staging";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore {{package_name.dotCase()}}.staging";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -842,7 +842,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
-				APP_DISPLAY_NAME = "Flutter Templates Production";
+				APP_DISPLAY_NAME = "{{app_name.titleCase()}} Production";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
@@ -855,9 +855,9 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = co.nimblehq.flutter.template;
+				PRODUCT_BUNDLE_IDENTIFIER = {{package_name.dotCase()}};
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore co.nimblehq.flutter.template";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore {{package_name.dotCase()}}";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -918,7 +918,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
-				APP_DISPLAY_NAME = "Flutter Templates Staging";
+				APP_DISPLAY_NAME = "{{app_name.titleCase()}} Staging";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
@@ -930,9 +930,9 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = co.nimblehq.flutter.template.staging;
+				PRODUCT_BUNDLE_IDENTIFIER = {{package_name.dotCase()}}.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc co.nimblehq.flutter.template.staging";
+				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc {{package_name.dotCase()}}.staging";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -993,7 +993,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
-				APP_DISPLAY_NAME = "Flutter Templates Production";
+				APP_DISPLAY_NAME = "{{app_name.titleCase()}} Production";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
@@ -1006,9 +1006,9 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = co.nimblehq.flutter.template;
+				PRODUCT_BUNDLE_IDENTIFIER = {{package_name.dotCase()}};
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore co.nimblehq.flutter.template";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore {{package_name.dotCase()}}";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/bricks/template/__brick__/template/ios/Runner.xcodeproj/project.pbxproj
+++ b/bricks/template/__brick__/template/ios/Runner.xcodeproj/project.pbxproj
@@ -685,7 +685,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
-				APP_DISPLAY_NAME = "{{app_name.titleCase()}} Production";
+				APP_DISPLAY_NAME = "{{app_name.titleCase()}}";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
@@ -842,7 +842,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
-				APP_DISPLAY_NAME = "{{app_name.titleCase()}} Production";
+				APP_DISPLAY_NAME = "{{app_name.titleCase()}}";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
@@ -993,7 +993,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
-				APP_DISPLAY_NAME = "{{app_name.titleCase()}} Production";
+				APP_DISPLAY_NAME = "{{app_name.titleCase()}}";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";

--- a/bricks/template/__brick__/template/ios/Runner/Info.plist
+++ b/bricks/template/__brick__/template/ios/Runner/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>flutter_templates</string>
+	<string>{{project_name.snakeCase()}}</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/bricks/template/__brick__/template/ios/fastlane/Constants/Constants.rb
+++ b/bricks/template/__brick__/template/ios/fastlane/Constants/Constants.rb
@@ -17,12 +17,12 @@ class Constants
 
   # bundle ID for Staging app
   def self.BUNDLE_ID_STAGING
-    'co.nimblehq.flutter.template.staging'
+    '{{package_name.dotCase()}}.staging'
   end
 
   # bundle ID for Production app
   def self.BUNDLE_ID_PRODUCTION
-    'co.nimblehq.flutter.template'
+    '{{package_name.dotCase()}}'
   end
 
   #################


### PR DESCRIPTION
- Solves #157

## What happened 👀

- Config `app_name`, `package_name` and `project_name` for iOS module dynamically so we can be able to generate a new project with the desired name.

## Insight 📝
- [Convention reference](https://github.com/felangel/mason/tree/master/packages/mason_cli#built-in-lambdas)
- Replace `Flutter Templates` with `app_name`, which follows title case convention
- Replace `co.nimblehq.flutter.template` with `package_name`, which follow dot case convention
- Replace `flutter_templates` with `project_name`, which follows snake case convention

## Proof Of Work 📹

<img src="https://user-images.githubusercontent.com/60863885/229408036-cf0df642-8922-447d-af43-13a0b39f21d5.png" width=200 />

Log:
```
 ~/Desktop/nimble/github/flutter_templates  feature/157-…ule-to-mason !3  mason make template -o generated/                                                                                            64 ✘  flutter_templates   10:42:10 
? Package name? (co.nimblehq.template) com.manhios
? App name? (Your App Name) Manh iOS module
? Project name? (your_project_name) ios_module_integration
? App version? (0.1.0) 0.1.0
? Build number? (1) 1
✓ Made brick template (0.4s)
✓ Generated 114 file(s):
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/test_driver/integration_test.dart (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/integration_test/utils/test_util.dart (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/integration_test/real_app_test.dart (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/integration_test/my_home_page_test.dart (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/codecov.yml (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/test/mocks/generate_mocks.dart (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/test/api/repository/credential_repository_test.dart (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/.env.sample (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/l10n.yaml (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/.metadata (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/pubspec.lock (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner.xcworkspace/contents.xcworkspacedata (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Runner-Bridging-Header.h (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Assets.xcassets/LaunchImage.imageset/LaunchImage@2x.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Assets.xcassets/LaunchImage.imageset/LaunchImage@3x.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Assets.xcassets/LaunchImage.imageset/README.md (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Assets.xcassets/LaunchImage.imageset/Contents.json (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Assets.xcassets/LaunchImage.imageset/LaunchImage.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-76x76@2x.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-29x29@1x.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-40x40@1x.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-20x20@1x.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-1024x1024@1x.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-83.5x83.5@2x.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-20x20@3x.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Assets.xcassets/AppIcon.appiconset/Contents.json (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-20x20@2x.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-29x29@3x.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-40x40@2x.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-60x60@3x.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-60x60@2x.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-76x76@1x.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-40x40@3x.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-29x29@2x.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Base.lproj/LaunchScreen.storyboard (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Base.lproj/Main.storyboard (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/AppDelegate.swift (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner/Info.plist (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner.xcodeproj/project.pbxproj (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner.xcodeproj/xcshareddata/xcschemes/production.xcscheme (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Runner.xcodeproj/xcshareddata/xcschemes/staging.xcscheme (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Flutter/Debug.xcconfig (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Flutter/Release.xcconfig (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Flutter/AppFrameworkInfo.plist (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/.gitignore (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/fastlane/Gymfile (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/fastlane/Constants/Environments.rb (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/fastlane/Constants/Constants.rb (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/fastlane/Managers/BuildManager.rb (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/fastlane/Managers/MatchManager.rb (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/fastlane/Managers/DistributionManager.rb (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/fastlane/Fastfile (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/fastlane/Matchfile (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Gemfile (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Gemfile.lock (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Podfile (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/ios/Podfile.lock (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/README.md (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/pubspec.yaml (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/.gitignore (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/android/app/build.gradle (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/android/app/src/staging/res/values/strings.xml (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/android/app/src/profile/AndroidManifest.xml (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/android/app/src/main/res/mipmap-mdpi/ic_launcher.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/android/app/src/main/res/mipmap-hdpi/ic_launcher.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/android/app/src/main/res/drawable/launch_background.xml (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/android/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/android/app/src/main/res/mipmap-xxhdpi/ic_launcher.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/android/app/src/main/res/values-night/styles.xml (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/android/app/src/main/res/values/styles.xml (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/android/app/src/main/res/values/strings.xml (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/android/app/src/main/res/drawable-v21/launch_background.xml (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/android/app/src/main/res/mipmap-xhdpi/ic_launcher.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/android/app/src/main/AndroidManifest.xml (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/android/app/src/main/kotlin/co/nimblehq/flutter/template/MainActivity.kt (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/android/app/src/debug/AndroidManifest.xml (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/android/gradle/wrapper/gradle-wrapper.properties (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/android/.gitignore (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/android/build.gradle (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/android/gradle.properties (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/android/settings.gradle (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/.github/CODEOWNERS (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/.github/workflows/test.yml (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/.github/workflows/ios_deploy_to_testflight.yml (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/.github/workflows/ios_deploy_to_app_store.yml (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/.github/PULL_REQUEST_TEMPLATE.md (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/.github/PULL_REQUEST_TEMPLATE/release_template.md (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/.github/ISSUE_TEMPLATE/feature_template.md (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/.github/ISSUE_TEMPLATE/story_template.md (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/.github/ISSUE_TEMPLATE/bug_template.md (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/.github/ISSUE_TEMPLATE/chore_template.md (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/lib/l10n/app_th.arb (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/lib/l10n/app_en.arb (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/lib/l10n/app_vi.arb (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/lib/di/provider/dio_provider.dart (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/lib/di/interceptor/app_interceptor.dart (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/lib/utils/wrappers/permission_wrapper.dart (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/lib/main.dart (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/lib/model/response/user_response.dart (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/lib/env.dart (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/lib/api/repository/credential_repository.dart (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/lib/api/api_service.dart (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/lib/api/exception/network_exceptions.dart (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/lib/usecases/base/base_use_case.dart (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/lib/usecases/base/use_case_result.dart (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/analysis_options.yaml (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/build.yaml (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/assets/images/nimble_logo.png (new)
  /Users/tranmanh/Desktop/nimble/github/flutter_templates/generated/template/assets/fonts/neuzeit.otf (new)
```
