### PR TITLE
[#184] [Generate project with Mason] Update necessary CI/CD workflows to use the new script

### DIFF
--- a/.github/workflows/android_deploy_production.yml
+++ b/.github/workflows/android_deploy_production.yml
@@ -14,14 +14,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-
-      - name: Generate new project
-        run: make run PACKAGE_NAME=co.nimblehq.flutter.template PROJECT_NAME=flutter_templates APP_NAME="Flutter Templates"
-
       - name: Set up Java JDK
         uses: actions/setup-java@v3
         with:
@@ -33,6 +25,14 @@ jobs:
         with:
           channel: 'stable'
           flutter-version: '3.3.10'
+
+      - name: Generate new project
+        run: |
+          dart pub global activate mason_cli
+          mason get
+          mason make template -c mason-config.json
+          rsync -av --remove-source-files flutter_templates/ ./
+          rm -rf bricks/template
 
       - name: Get Flutter dependencies
         run: flutter pub get

--- a/.github/workflows/android_deploy_production.yml
+++ b/.github/workflows/android_deploy_production.yml
@@ -31,6 +31,7 @@ jobs:
           dart pub global activate mason_cli
           mason get
           mason make template -c mason-config.json
+          # Move the generated project to the root directory for next steps & cleanup to not affect static code analysis
           rsync -av --remove-source-files flutter_templates/ ./
           rm -rf bricks/template
 

--- a/.github/workflows/android_deploy_production_to_playstore.yml
+++ b/.github/workflows/android_deploy_production_to_playstore.yml
@@ -14,14 +14,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-
-      - name: Generate new project
-        run: make run PACKAGE_NAME=co.nimblehq.flutter.template PROJECT_NAME=flutter_templates APP_NAME="Flutter Templates"
-
       - name: Set up Java JDK
         uses: actions/setup-java@v3
         with:
@@ -33,6 +25,14 @@ jobs:
         with:
           channel: 'stable'
           flutter-version: '3.3.10'
+
+      - name: Generate new project
+        run: |
+          dart pub global activate mason_cli
+          mason get
+          mason make template -c mason-config.json
+          rsync -av --remove-source-files flutter_templates/ ./
+          rm -rf bricks/template
 
       - name: Get Flutter dependencies
         run: flutter pub get

--- a/.github/workflows/android_deploy_production_to_playstore.yml
+++ b/.github/workflows/android_deploy_production_to_playstore.yml
@@ -31,6 +31,7 @@ jobs:
           dart pub global activate mason_cli
           mason get
           mason make template -c mason-config.json
+          # Move the generated project to the root directory for next steps & cleanup to not affect static code analysis
           rsync -av --remove-source-files flutter_templates/ ./
           rm -rf bricks/template
 

--- a/.github/workflows/android_deploy_staging.yml
+++ b/.github/workflows/android_deploy_staging.yml
@@ -32,6 +32,7 @@ jobs:
           dart pub global activate mason_cli
           mason get
           mason make template -c mason-config.json
+          # Move the generated project to the root directory for next steps & cleanup to not affect static code analysis
           rsync -av --remove-source-files flutter_templates/ ./
           rm -rf bricks/template
 

--- a/.github/workflows/android_deploy_staging.yml
+++ b/.github/workflows/android_deploy_staging.yml
@@ -15,14 +15,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-
-      - name: Generate new project
-        run: make run PACKAGE_NAME=co.nimblehq.flutter.template PROJECT_NAME=flutter_templates APP_NAME="Flutter Templates"
-
       - name: Set up Java JDK
         uses: actions/setup-java@v3
         with:
@@ -34,6 +26,14 @@ jobs:
         with:
           channel: 'stable'
           flutter-version: '3.3.10'
+
+      - name: Generate new project
+        run: |
+          dart pub global activate mason_cli
+          mason get
+          mason make template -c mason-config.json
+          rsync -av --remove-source-files flutter_templates/ ./
+          rm -rf bricks/template
 
       - name: Get Flutter dependencies
         run: flutter pub get

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -20,9 +20,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set new version
-        id: set_version
-        run: |
-          perl -i -pe 's/^(version:\s+\d+\.\d+\.\d+\+)(\d+)$/"version: ${{ github.event.inputs.newVersion }}+".($2+1)/e' ./template/pubspec.yaml
+        uses: jossef/action-set-json-field@v2.1
+        with:
+          file: mason-config.json
+          field: app_version
+          value: ${{ github.event.inputs.newVersion }}
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Checkout the latest code
+      - name: Checkout
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ios_deploy_staging_to_firebase.yml
+++ b/.github/workflows/ios_deploy_staging_to_firebase.yml
@@ -21,14 +21,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-
-      - name: Generate new project
-        run: make run PACKAGE_NAME=co.nimblehq.flutter.template PROJECT_NAME=flutter_templates APP_NAME="Flutter Templates"
-
       - name: Install SSH key
         uses: webfactory/ssh-agent@v0.4.1
         with:
@@ -39,6 +31,14 @@ jobs:
         with:
           channel: 'stable'
           flutter-version: '3.3.10'
+
+      - name: Generate new project
+        run: |
+          dart pub global activate mason_cli
+          mason get
+          mason make template -c mason-config.json
+          rsync -av --remove-source-files flutter_templates/ ./
+          rm -rf bricks/template
 
       - name: Get Flutter dependencies
         run: flutter pub get

--- a/.github/workflows/ios_deploy_staging_to_firebase.yml
+++ b/.github/workflows/ios_deploy_staging_to_firebase.yml
@@ -19,7 +19,7 @@ jobs:
       KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/ios_deploy_staging_to_firebase.yml
+++ b/.github/workflows/ios_deploy_staging_to_firebase.yml
@@ -37,6 +37,7 @@ jobs:
           dart pub global activate mason_cli
           mason get
           mason make template -c mason-config.json
+          # Move the generated project to the root directory for next steps & cleanup to not affect static code analysis
           rsync -av --remove-source-files flutter_templates/ ./
           rm -rf bricks/template
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           dart pub global activate mason_cli
           mason get
-          mason make template --project_name "flutter_templates" --package_name "co.nimblehq.flutter.template" --app_name "Flutter Templates" --app_version "1.7.0" --build_number "17"
+          mason make template -c mason-config.json
           rsync -av --remove-source-files flutter_templates/ ./
           rm -rf bricks/template
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
           dart pub global activate mason_cli
           mason get
           mason make template -c mason-config.json
+          # Move the generated project to the root directory for next steps & cleanup to not affect static code analysis
           rsync -av --remove-source-files flutter_templates/ ./
           rm -rf bricks/template
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,49 +1,49 @@
-# TODO: Edit the CICD workflow after integrating Mason successfully.
-# name: CI
-# on:
-#   # Trigger the workflow on push or pull request,
-#   # but push action is only for the feature branch
-#   pull_request:
-#     types: [ opened, synchronize, reopened ]
-#   push:
-#     branches-ignore:
-#       - develop
-#       - 'release/**'
-#       - main
+name: CI
+on:
+  # Trigger the workflow on push or pull request,
+  # but push action is only for the feature branch
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+  push:
+    branches-ignore:
+      - develop
+      - 'release/**'
+      - main
 
-# jobs:
-#   test:
-#     name: Template initializing scripts test
-#     runs-on: ubuntu-latest
-#     timeout-minutes: 30
-#     steps:
-#       - uses: actions/checkout@v2.3.2
+jobs:
+  test:
+    name: Template initializing scripts test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-#       - name: Set up Python
-#         uses: actions/setup-python@v2
-#         with:
-#           python-version: '3.9'
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
 
-#       - name: Generate new project
-#         run: make run PACKAGE_NAME=co.nimblehq.flutter.template PROJECT_NAME=flutter_templates APP_NAME="Flutter Templates"
+      - name: Generate new project
+        run: make run PACKAGE_NAME=co.nimblehq.flutter.template PROJECT_NAME=flutter_templates APP_NAME="Flutter Templates"
 
-#       - name: Set up Flutter environment
-#         uses: subosito/flutter-action@v2
-#         with:
-#           channel: 'stable'
-#           flutter-version: '3.3.10'
+      - name: Set up Flutter environment
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          flutter-version: '3.3.10'
 
-#       - name: Get Flutter dependencies
-#         run: flutter pub get
+      - name: Get Flutter dependencies
+        run: flutter pub get
 
-#       - name: Run code generator
-#         run: flutter packages pub run build_runner build --delete-conflicting-outputs
+      - name: Run code generator
+        run: flutter packages pub run build_runner build --delete-conflicting-outputs
 
-#       - name: Check for any formatting issues in the code
-#         run: flutter format --set-exit-if-changed .
+      - name: Check for any formatting issues in the code
+        run: flutter format --set-exit-if-changed .
 
-#       - name: Statically analyze the Dart code for any errors
-#         run: flutter analyze .
+      - name: Statically analyze the Dart code for any errors
+        run: flutter analyze .
 
-#       - name: Run widget tests, unit tests
-#         run: flutter test --machine --coverage
+      - name: Run widget tests, unit tests
+        run: flutter test --machine --coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
           mason get
           mason make template --project_name "flutter_templates" --package_name "co.nimblehq.flutter.template" --app_name "Flutter Templates" --app_version "1.7.0" --build_number "17"
           rsync -av --remove-source-files flutter_templates/ ./
+          rm -rf bricks/template
 
       - name: Get Flutter dependencies
         run: flutter pub get

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,19 +19,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-
-      - name: Generate new project
-        run: make run PACKAGE_NAME=co.nimblehq.flutter.template PROJECT_NAME=flutter_templates APP_NAME="Flutter Templates"
-
       - name: Set up Flutter environment
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
           flutter-version: '3.3.10'
+
+      - name: Generate new project
+        run: |
+          dart pub global activate mason_cli
+          mason get
+          mason make template --project_name "flutter_templates" --package_name "co.nimblehq.flutter.template" --app_name "Flutter Templates" --app_version "1.7.0" --build_number "17"
+          rsync -av --remove-source-files flutter_templates/ ./
 
       - name: Get Flutter dependencies
         run: flutter pub get

--- a/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/bump_version.yml
+++ b/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/bump_version.yml
@@ -20,7 +20,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set new version
-        id: set_version
         run: |
           perl -i -pe 's/^(version:\s+\d+\.\d+\.\d+\+)(\d+)$/"version: ${{ github.event.inputs.newVersion }}+".($2+1)/e' ./pubspec.yaml
 

--- a/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/bump_version.yml
+++ b/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/bump_version.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Checkout the latest code
+      - name: Checkout
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/ios_deploy_staging_to_firebase.yml
+++ b/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/ios_deploy_staging_to_firebase.yml
@@ -19,7 +19,7 @@ jobs:
       KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install SSH key
         uses: webfactory/ssh-agent@v0.4.1

--- a/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/ios_deploy_to_app_store.yml
+++ b/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/ios_deploy_to_app_store.yml
@@ -19,7 +19,8 @@ jobs:
       MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
       KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
     steps:
-    - uses: actions/checkout@v1
+    - name: Checkout
+      uses: actions/checkout@v3
 
     - name: Install SSH key
       uses: webfactory/ssh-agent@v0.4.1

--- a/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/ios_deploy_to_testflight.yml
+++ b/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/ios_deploy_to_testflight.yml
@@ -19,7 +19,8 @@ jobs:
       MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
       KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
     steps:
-    - uses: actions/checkout@v1
+    - name: Checkout
+      uses: actions/checkout@v3
 
     - name: Install SSH key
       uses: webfactory/ssh-agent@v0.4.1

--- a/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/test.yml
+++ b/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/test.yml
@@ -15,7 +15,8 @@ jobs:
     timeout-minutes: 30
     environment: staging
     steps:
-      - uses: actions/checkout@v2.3.2
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Set up Flutter environment
         uses: subosito/flutter-action@v2
@@ -38,7 +39,7 @@ jobs:
       - name: Run widget tests, unit tests
         run: flutter test --machine --coverage
 
-      - name: Upload coverage to codecov 
+      - name: Upload coverage to codecov
         uses: codecov/codecov-action@v2
         with:
           files: ./coverage/lcov.info

--- a/mason-config.json
+++ b/mason-config.json
@@ -1,0 +1,7 @@
+{
+    "project_name": "flutter_templates",
+    "package_name": "co.nimblehq.flutter.template",
+    "app_name": "Flutter Templates",
+    "app_version": "1.7.0",
+    "build_number": "17"
+}

--- a/mason-config.json
+++ b/mason-config.json
@@ -3,5 +3,5 @@
     "package_name": "co.nimblehq.flutter.template",
     "app_name": "Flutter Templates",
     "app_version": "1.7.0",
-    "build_number": "17"
+    "build_number": "1"
 }


### PR DESCRIPTION
- Solves #184

## What happened 👀

- Replace the Python script.
- Update necessary CI/CD workflows to use the new script:
  - [test.yml](https://github.com/nimblehq/flutter-templates/blob/develop/.github/workflows/test.yml).
  - [android_deploy_staging.yml](https://github.com/nimblehq/flutter-templates/blob/develop/.github/workflows/android_deploy_staging.yml)
  - [android_deploy_production_to_playstore.yml](https://github.com/nimblehq/flutter-templates/blob/develop/.github/workflows/android_deploy_production_to_playstore.yml)
  - [android_deploy_production.yml](https://github.com/nimblehq/flutter-templates/blob/develop/.github/workflows/android_deploy_production.yml)

## Insight 📝

- According to the Mason documentation, [any variables which aren't specified as command line args will be prompted](https://github.com/felangel/mason/tree/master/packages/mason_cli#variable-prompts). The updated Mason command to generate is:
  ```
  mason make template --project_name "flutter_templates" --package_name "co.nimblehq.flutter.template" --app_name "Flutter Templates" --app_version "1.0.0" --build_number "1"
  ```
- To simplify the sample project information management, we can use [a JSON config file](https://github.com/felangel/mason/tree/master/packages/mason_cli#config-file-for-input-variables) `mason-config.json`
  ```
  {
      "project_name": "flutter_templates",
      "package_name": "co.nimblehq.flutter.template",
      "app_name": "Flutter Templates",
      "app_version": "1.7.0",
      "build_number": "1"
  }
  ```
  The command becomes simple now 🎉 
  ```
  mason make template -c mason-config.json
  ```

- We no longer need to set up Python, so replace it with `dart pub global activate mason_cli`.
- We need to move all generated files back to the root folder & remove the Mason template not to effect the static code analysis.
- We have to update the logic of the `bump_version` workflow at the root project to bump the new version to the `mason-config.json` file instead of directly to `pubspec.yaml` for generating 🚀 

## Proof Of Work 📹

- test.yml: https://github.com/nimblehq/flutter-templates/actions/runs/4827684980/jobs/8600671193 ✅ 
- android_deploy_staging.yml: https://github.com/nimblehq/flutter-templates/actions/runs/4827778127/jobs/8600858504 ✅ 
- bump_version.yml: https://github.com/nimblehq/flutter-templates/pull/192 ✅ 
