### PR TITLE
[#206] Fix: "flutter analyze ." command in CI workflow reports issues with new "sample" project folder

### DIFF
--- a/.github/workflows/android_deploy_production.yml
+++ b/.github/workflows/android_deploy_production.yml
@@ -33,7 +33,7 @@ jobs:
           mason make template -c mason-config.json
           # Move the generated project to the root directory for next steps & cleanup to not affect static code analysis
           rsync -av --remove-source-files flutter_templates/ ./
-          rm -rf bricks/template
+          rm -rf bricks sample
 
       - name: Get Flutter dependencies
         run: flutter pub get

--- a/.github/workflows/android_deploy_production_to_playstore.yml
+++ b/.github/workflows/android_deploy_production_to_playstore.yml
@@ -33,7 +33,7 @@ jobs:
           mason make template -c mason-config.json
           # Move the generated project to the root directory for next steps & cleanup to not affect static code analysis
           rsync -av --remove-source-files flutter_templates/ ./
-          rm -rf bricks/template
+          rm -rf bricks sample
 
       - name: Get Flutter dependencies
         run: flutter pub get

--- a/.github/workflows/android_deploy_staging.yml
+++ b/.github/workflows/android_deploy_staging.yml
@@ -34,7 +34,7 @@ jobs:
           mason make template -c mason-config.json
           # Move the generated project to the root directory for next steps & cleanup to not affect static code analysis
           rsync -av --remove-source-files flutter_templates/ ./
-          rm -rf bricks/template
+          rm -rf bricks sample
 
       - name: Get Flutter dependencies
         run: flutter pub get

--- a/.github/workflows/ios_deploy_staging_to_firebase.yml
+++ b/.github/workflows/ios_deploy_staging_to_firebase.yml
@@ -39,7 +39,7 @@ jobs:
           mason make template -c mason-config.json
           # Move the generated project to the root directory for next steps & cleanup to not affect static code analysis
           rsync -av --remove-source-files flutter_templates/ ./
-          rm -rf bricks/template
+          rm -rf bricks sample
 
       - name: Get Flutter dependencies
         run: flutter pub get

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           mason make template -c mason-config.json
           # Move the generated project to the root directory for next steps & cleanup to not affect static code analysis
           rsync -av --remove-source-files flutter_templates/ ./
-          rm -rf bricks/template
+          rm -rf bricks sample
 
       - name: Get Flutter dependencies
         run: flutter pub get


### PR DESCRIPTION
- Solves #206

## What happened 👀

@manh-t found the bug in this PR https://github.com/nimblehq/flutter-templates/pull/203 and [has a fix](https://github.com/nimblehq/flutter-templates/pull/203/commits/2a29fb282e2077029ff9ff11eab9fd637e070d71) to bypass the issue. However, we just need to remove 1 more `sample` folder as `flutter_templates` has been moved to the root.

## Insight 📝

The workflows will work on the root project instead of the `sample`.

## Proof Of Work 📹

`flutter analyze .` command is back to pass ✅ 

https://github.com/nimblehq/flutter-templates/actions/runs/5154106600/jobs/9282150402?pr=207
