### PR TITLE
[Chore] Improve: skip git push action if there are no changes from the sample project

### DIFF
--- a/.github/workflows/generate_sample.yml
+++ b/.github/workflows/generate_sample.yml
@@ -6,7 +6,9 @@ on:
       - develop
 
 jobs:
-  test:
+  generate_sample_project:
+    # Run on merge commits only
+    if: ${{ contains(github.event.head_commit.message, 'Merge pull request') || (github.event.head_commit.author.email != 'bot@nimblehq.co') }}
     name: Generate the sample project
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/generate_sample.yml
+++ b/.github/workflows/generate_sample.yml
@@ -39,7 +39,14 @@ jobs:
           mason get
           mason make template -c mason-config.json
 
+      - id: changes
+        name: Check for changes in the sample project
+        run: |
+          count=$(git status sample --porcelain | wc -l)
+          echo "count=$count" >> $GITHUB_OUTPUT
+
       - name: Commit & push the sample project changes
+        if: steps.changes.outputs.count > 0
         run: |
           git config user.name team-nimblehq
           git config user.email bot@nimblehq.co


### PR DESCRIPTION
- Solves #212

## What happened 👀

- Skip git push action if there are no changes from the sample project.
- Run the `generate sample project` workflow on the `merge commit` only to [avoid the status check to fail on `develop` after pushing the generated project commit](https://github.com/nimblehq/flutter-templates/commit/82144a0f043bec6c2a48fa743987aa78375e0b2f).

## Insight 📝

- Use `git status sample --porcelain | wc -l` to detect `file changed count` in the `sample` project folder.
- Check and run the `Commit & push the sample project changes` step if has changed.
- To check a commit is the merge commit, use `if: ${{ contains(github.event.head_commit.message, 'Merge pull request') || (github.event.head_commit.author.email != 'luong@nimblehq.co') }}`.

## Proof Of Work 📹

- **Skip git push action if there are no changes from the sample project**

	- No changes: https://github.com/nimblehq/flutter-templates/actions/runs/5472746031
	
	- Has changes: https://github.com/nimblehq/flutter-templates/actions/runs/5472737436
	
	  ![image](https://github.com/nimblehq/flutter-templates/assets/16315358/4cb065ce-bfba-4600-b504-08ce1fc0d8d1)

- **The workflow is now only run on the merge commit on develop**

  ![image](https://github.com/nimblehq/flutter-templates/assets/16315358/64b64e8c-9f92-4db0-afb6-5d37125d414e)
