### PR TITLE
[#200] Fix: The new project generator with Mason removes all variable params with ${{ }} format in workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Team
 # @luongvo is the Team Lead
-* @manh-t @doannimble @luongvo @markgravity @sleepylee @chornerman
+* @luongvo @manh-t @markgravity @sleepylee @chornerman @doannimble @hoangnguyen92dn @nmint8m @ducbm051291 @thiennguyen0196 @kaungkhantsoe @Shayokh144 @Tuubz @Wadeewee
 
 # Engineering Leads
 CODEOWNERS @nimblehq/engineering-leads

--- a/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/CODEOWNERS
+++ b/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Team
-# @manh-t is the Team Lead
-* @manh-t @doannimble @luongvo @markgravity
+# @teamlead is the Team Lead
+* @teammember1 @teammember2
 
 # Engineering Leads
 CODEOWNERS @nimblehq/engineering-leads

--- a/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/android_deploy_production.yml
+++ b/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/android_deploy_production.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Set up .env
         env:
-          ENV_PRODUCTION: ${{ secrets.ENV_PRODUCTION }}
+          ENV_PRODUCTION: ${{#mustacheCase}}secrets.ENV_PRODUCTION{{/mustacheCase}}
         run: |
           echo $ENV_PRODUCTION > .env
 
@@ -45,7 +45,7 @@ jobs:
       - name: Deploy Android Production to Firebase
         uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
         with:
-          appId: ${{ secrets.FIREBASE_ANDROID_APP_ID_PRODUCTION }}
-          serviceCredentialsFileContent: ${{ secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON }}
+          appId: ${{#mustacheCase}}secrets.FIREBASE_ANDROID_APP_ID_PRODUCTION{{/mustacheCase}}
+          serviceCredentialsFileContent: ${{#mustacheCase}}secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON{{/mustacheCase}}
           groups: nimble
           file: build/app/outputs/flutter-apk/app-production-debug.apk

--- a/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/android_deploy_production_to_playstore.yml
+++ b/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/android_deploy_production_to_playstore.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Set up .env
         env:
-          ENV_PRODUCTION: ${{ secrets.ENV_PRODUCTION }}
+          ENV_PRODUCTION: ${{#mustacheCase}}secrets.ENV_PRODUCTION{{/mustacheCase}}
         run: |
           echo $ENV_PRODUCTION > .env
 
@@ -44,8 +44,8 @@ jobs:
       - name: Upload Android Production Release bundle to Play Store
         uses: r0adkll/upload-google-play@v1
         with:
-          serviceAccountJson: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
-          packageName: co.nimblehq.flutter.template
+          serviceAccountJson: ${{#mustacheCase}}secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON{{/mustacheCase}}
+          packageName: {{package_name.dotCase()}}
           releaseFile: build/app/outputs/bundle/productionRelease/app-production-release.aab
           track: internal
           userFraction: 1.0

--- a/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/android_deploy_staging.yml
+++ b/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/android_deploy_staging.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Set up .env.staging
         env:
-          ENV_STAGING: ${{ secrets.ENV_STAGING }}
+          ENV_STAGING: ${{#mustacheCase}}secrets.ENV_STAGING{{/mustacheCase}}
         run: |
           echo $ENV_STAGING > .env.staging
 
@@ -45,7 +45,7 @@ jobs:
       - name: Deploy Android Staging to Firebase
         uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
         with:
-          appId: ${{ secrets.FIREBASE_ANDROID_APP_ID_STAGING }}
-          serviceCredentialsFileContent: ${{ secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON }}
+          appId: ${{#mustacheCase}}secrets.FIREBASE_ANDROID_APP_ID_STAGING{{/mustacheCase}}
+          serviceCredentialsFileContent: ${{#mustacheCase}}secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON{{/mustacheCase}}
           groups: nimble
           file: build/app/outputs/flutter-apk/app-staging-debug.apk

--- a/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/bump_version.yml
+++ b/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/bump_version.yml
@@ -17,28 +17,28 @@ jobs:
       - name: Check out
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{#mustacheCase}}secrets.GITHUB_TOKEN{{/mustacheCase}}
 
       - name: Set new version
         run: |
-          perl -i -pe 's/^(version:\s+\d+\.\d+\.\d+\+)(\d+)$/"version: ${{ github.event.inputs.newVersion }}+".($2+1)/e' ./pubspec.yaml
+          perl -i -pe 's/^(version:\s+\d+\.\d+\.\d+\+)(\d+)$/"version: ${{#mustacheCase}}github.event.inputs.newVersion{{/mustacheCase}}+".($2+1)/e' ./pubspec.yaml
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v4
         with:
-          assignees: ${{ secrets.GITHUB_USER }}
-          token: ${{ secrets.WIKI_ACTION_TOKEN }}
-          commit-message: Bump version to ${{ github.event.inputs.newVersion }}
+          assignees: ${{#mustacheCase}}secrets.GITHUB_USER{{/mustacheCase}}
+          token: ${{#mustacheCase}}secrets.WIKI_ACTION_TOKEN{{/mustacheCase}}
+          commit-message: Bump version to ${{#mustacheCase}}github.event.inputs.newVersion{{/mustacheCase}}
           committer: Nimble Bot <bot@nimblehq.co>
-          branch: chore/bump-version-to-${{ github.event.inputs.newVersion }}
+          branch: chore/bump-version-to-${{#mustacheCase}}github.event.inputs.newVersion{{/mustacheCase}}
           delete-branch: true
-          title: '[Chore] Bump version to ${{ github.event.inputs.newVersion }}'
+          title: '[Chore] Bump version to ${{#mustacheCase}}github.event.inputs.newVersion{{/mustacheCase}}'
           labels: |
             type : chore
           body: |
             ## What happened 👀
 
-            Bump version to ${{ github.event.inputs.newVersion }}
+            Bump version to ${{#mustacheCase}}github.event.inputs.newVersion{{/mustacheCase}}
 
             ## Insight 📝
 

--- a/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/ios_deploy_staging_to_firebase.yml
+++ b/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/ios_deploy_staging_to_firebase.yml
@@ -10,13 +10,13 @@ jobs:
     name: Build And Upload iOS Staging Application To Firebase
     runs-on: macOS-latest
     env:
-      TEAM_ID: ${{ secrets.TEAM_ID }}
-      FASTLANE_USER: ${{ secrets.FASTLANE_USER }}
-      FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
-      FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
-      FASTLANE_SESSION: ${{ secrets.FASTLANE_SESSION }}
-      MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-      KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+      TEAM_ID: ${{#mustacheCase}}secrets.TEAM_ID{{/mustacheCase}}
+      FASTLANE_USER: ${{#mustacheCase}}secrets.FASTLANE_USER{{/mustacheCase}}
+      FASTLANE_PASSWORD: ${{#mustacheCase}}secrets.FASTLANE_PASSWORD{{/mustacheCase}}
+      FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{#mustacheCase}}secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD{{/mustacheCase}}
+      FASTLANE_SESSION: ${{#mustacheCase}}secrets.FASTLANE_SESSION{{/mustacheCase}}
+      MATCH_PASSWORD: ${{#mustacheCase}}secrets.MATCH_PASSWORD{{/mustacheCase}}
+      KEYCHAIN_PASSWORD: ${{#mustacheCase}}secrets.KEYCHAIN_PASSWORD{{/mustacheCase}}
     steps:
       - name: Check out
         uses: actions/checkout@v3
@@ -24,7 +24,7 @@ jobs:
       - name: Install SSH key
         uses: webfactory/ssh-agent@v0.4.1
         with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key: ${{#mustacheCase}}secrets.SSH_PRIVATE_KEY{{/mustacheCase}}
 
       - name: Set up Flutter environment
         uses: subosito/flutter-action@v1
@@ -37,7 +37,7 @@ jobs:
 
       - name: Set up .env.staging
         env:
-          ENV_STAGING: ${{ secrets.ENV_STAGING }}
+          ENV_STAGING: ${{#mustacheCase}}secrets.ENV_STAGING{{/mustacheCase}}
         run: |
           echo $ENV_STAGING > .env.staging
 
@@ -57,4 +57,4 @@ jobs:
         run: |
           cd ./ios && bundle exec fastlane build_and_upload_staging_app
         env:
-          FIREBASE_CLI_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
+          FIREBASE_CLI_TOKEN: ${{#mustacheCase}}secrets.FIREBASE_CLI_TOKEN{{/mustacheCase}}

--- a/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/ios_deploy_to_app_store.yml
+++ b/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/ios_deploy_to_app_store.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: macOS-latest
     timeout-minutes: 30
     env:
-      TEAM_ID: ${{ secrets.TEAM_ID }}
-      FASTLANE_USER: ${{ secrets.FASTLANE_USER }}
-      FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
-      FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
-      FASTLANE_SESSION: ${{ secrets.FASTLANE_SESSION }}
-      MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-      KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+      TEAM_ID: ${{#mustacheCase}}secrets.TEAM_ID{{/mustacheCase}}
+      FASTLANE_USER: ${{#mustacheCase}}secrets.FASTLANE_USER{{/mustacheCase}}
+      FASTLANE_PASSWORD: ${{#mustacheCase}}secrets.FASTLANE_PASSWORD{{/mustacheCase}}
+      FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{#mustacheCase}}secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD{{/mustacheCase}}
+      FASTLANE_SESSION: ${{#mustacheCase}}secrets.FASTLANE_SESSION{{/mustacheCase}}
+      MATCH_PASSWORD: ${{#mustacheCase}}secrets.MATCH_PASSWORD{{/mustacheCase}}
+      KEYCHAIN_PASSWORD: ${{#mustacheCase}}secrets.KEYCHAIN_PASSWORD{{/mustacheCase}}
     steps:
     - name: Check out
       uses: actions/checkout@v3
@@ -25,7 +25,7 @@ jobs:
     - name: Install SSH key
       uses: webfactory/ssh-agent@v0.4.1
       with:
-        ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+        ssh-private-key: ${{#mustacheCase}}secrets.SSH_PRIVATE_KEY{{/mustacheCase}}
 
     - name: Set up Flutter environment
       uses: subosito/flutter-action@v2

--- a/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/ios_deploy_to_testflight.yml
+++ b/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/ios_deploy_to_testflight.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: macOS-latest
     timeout-minutes: 30
     env:
-      TEAM_ID: ${{ secrets.TEAM_ID }}
-      FASTLANE_USER: ${{ secrets.FASTLANE_USER }}
-      FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
-      FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
-      FASTLANE_SESSION: ${{ secrets.FASTLANE_SESSION }}
-      MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-      KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+      TEAM_ID: ${{#mustacheCase}}secrets.TEAM_ID{{/mustacheCase}}
+      FASTLANE_USER: ${{#mustacheCase}}secrets.FASTLANE_USER{{/mustacheCase}}
+      FASTLANE_PASSWORD: ${{#mustacheCase}}secrets.FASTLANE_PASSWORD{{/mustacheCase}}
+      FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{#mustacheCase}}secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD{{/mustacheCase}}
+      FASTLANE_SESSION: ${{#mustacheCase}}secrets.FASTLANE_SESSION{{/mustacheCase}}
+      MATCH_PASSWORD: ${{#mustacheCase}}secrets.MATCH_PASSWORD{{/mustacheCase}}
+      KEYCHAIN_PASSWORD: ${{#mustacheCase}}secrets.KEYCHAIN_PASSWORD{{/mustacheCase}}
     steps:
     - name: Check out
       uses: actions/checkout@v3
@@ -25,7 +25,7 @@ jobs:
     - name: Install SSH key
       uses: webfactory/ssh-agent@v0.4.1
       with:
-        ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+        ssh-private-key: ${{#mustacheCase}}secrets.SSH_PRIVATE_KEY{{/mustacheCase}}
 
     - name: Set up Flutter environment
       uses: subosito/flutter-action@v2

--- a/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/test.yml
+++ b/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/test.yml
@@ -44,6 +44,6 @@ jobs:
         with:
           files: ./coverage/lcov.info
           flags: unittests # optional
-          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+          token: ${{#mustacheCase}}secrets.CODECOV_TOKEN{{/mustacheCase}} # not required for public repos
           fail_ci_if_error: false
           verbose: true


### PR DESCRIPTION
- Solves #200

## What happened 👀

- Fix: disable variable replacement by using `mustacheCase` https://github.com/felangel/mason/issues/367

## Insight 📝

This issue has been raised by other develops:
- https://github.com/felangel/mason/issues/160
- https://github.com/felangel/mason/issues/367

The best solution, for now, is using [mustacheCase](https://docs.brickhub.dev/brick-syntax#built-in-lambdas) to let `mason` generates mustache syntax for those workflow variables instead of understanding them as variables to replace ✅  

The final update will look like this:

```
${{ secrets.GITHUB_TOKEN }}
```
👇 
```
${{#mustacheCase}}secrets.GITHUB_TOKEN{{/mustacheCase}}
```

## Proof Of Work 📹

The workflows in generated project have variable params configured correctly. For example:

- `bump_version.yml`

<img width="783" alt="image" src="https://github.com/nimblehq/flutter-templates/assets/16315358/776fb554-adc0-4dbf-8d6b-8d59a1ffec1a">


- `android_deploy_production.yml`

<img width="785" alt="image" src="https://github.com/nimblehq/flutter-templates/assets/16315358/31157d1b-9aa9-4324-9622-964c83d95d4d">
