### PR TITLE
[#241] [iOS] Set "build-number" by "$GITHUB_RUN_NUMBER" when building the app bundle

### DIFF
--- a/.github/workflows/ios_deploy_staging_to_firebase.yml
+++ b/.github/workflows/ios_deploy_staging_to_firebase.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - feature/241-ios-github-run-number
 
 jobs:
   build_and_upload_staging_app_to_firebase:

--- a/.github/workflows/ios_deploy_staging_to_firebase.yml
+++ b/.github/workflows/ios_deploy_staging_to_firebase.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - feature/241-ios-github-run-number
 
 jobs:
   build_and_upload_staging_app_to_firebase:
@@ -20,6 +21,7 @@ jobs:
       FIREBASE_CLI_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
       FIREBASE_APP_ID_STAGING: ${{ secrets.FIREBASE_IOS_APP_ID_STAGING }}
       FIREBASE_DISTRIBUTION_TESTER_GROUPS: ${{ vars.FIREBASE_DISTRIBUTION_TESTER_GROUPS }}
+      GITHUB_RUN_NUMBER: $GITHUB_RUN_NUMBER
     steps:
       - name: Check out
         uses: actions/checkout@v3

--- a/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/ios_deploy_staging_to_firebase.yml
+++ b/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/ios_deploy_staging_to_firebase.yml
@@ -20,6 +20,7 @@ jobs:
       FIREBASE_CLI_TOKEN: ${{#mustacheCase}}secrets.FIREBASE_CLI_TOKEN{{/mustacheCase}}
       FIREBASE_APP_ID_STAGING: ${{#mustacheCase}}secrets.FIREBASE_IOS_APP_ID_STAGING{{/mustacheCase}}
       FIREBASE_DISTRIBUTION_TESTER_GROUPS: ${{#mustacheCase}}vars.FIREBASE_DISTRIBUTION_TESTER_GROUPS{{/mustacheCase}}
+      GITHUB_RUN_NUMBER: $GITHUB_RUN_NUMBER
     steps:
       - name: Check out
         uses: actions/checkout@v3

--- a/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/ios_deploy_to_app_store.yml
+++ b/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/ios_deploy_to_app_store.yml
@@ -18,6 +18,7 @@ jobs:
       FASTLANE_SESSION: ${{#mustacheCase}}secrets.FASTLANE_SESSION{{/mustacheCase}}
       MATCH_PASSWORD: ${{#mustacheCase}}secrets.MATCH_PASSWORD{{/mustacheCase}}
       KEYCHAIN_PASSWORD: ${{#mustacheCase}}secrets.KEYCHAIN_PASSWORD{{/mustacheCase}}
+      GITHUB_RUN_NUMBER: $secrets.GITHUB_RUN_NUMBER
     steps:
     - name: Check out
       uses: actions/checkout@v3

--- a/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/ios_deploy_to_testflight.yml
+++ b/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/ios_deploy_to_testflight.yml
@@ -18,6 +18,7 @@ jobs:
       FASTLANE_SESSION: ${{#mustacheCase}}secrets.FASTLANE_SESSION{{/mustacheCase}}
       MATCH_PASSWORD: ${{#mustacheCase}}secrets.MATCH_PASSWORD{{/mustacheCase}}
       KEYCHAIN_PASSWORD: ${{#mustacheCase}}secrets.KEYCHAIN_PASSWORD{{/mustacheCase}}
+      GITHUB_RUN_NUMBER: $secrets.GITHUB_RUN_NUMBER
     steps:
     - name: Check out
       uses: actions/checkout@v3

--- a/bricks/template/__brick__/{{project_name.snakeCase()}}/ios/fastlane/Constants/Environments.rb
+++ b/bricks/template/__brick__/{{project_name.snakeCase()}}/ios/fastlane/Constants/Environments.rb
@@ -30,4 +30,8 @@ class Environments
   def self.FIREBASE_TESTER_GROUPS
     ENV['FIREBASE_DISTRIBUTION_TESTER_GROUPS']
   end
+
+  def self.GITHUB_RUN_NUMBER
+    ENV["GITHUB_RUN_NUMBER"]
+  end
 end

--- a/bricks/template/__brick__/{{project_name.snakeCase()}}/ios/fastlane/Fastfile
+++ b/bricks/template/__brick__/{{project_name.snakeCase()}}/ios/fastlane/Fastfile
@@ -138,10 +138,10 @@ platform :ios do
     end
   end
 
-  desc 'set build number with number of commits'
+  desc 'set build number with the run number'
   private_lane :bump_build do
     increment_build_number(
-      build_number: number_of_commits,
+      build_number: Environments.GITHUB_RUN_NUMBER,
       xcodeproj: Constants.PROJECT_PATH
     )
   end

--- a/sample/ios/fastlane/Fastfile
+++ b/sample/ios/fastlane/Fastfile
@@ -138,7 +138,7 @@ platform :ios do
     end
   end
 
-  desc 'set build number with number of commits'
+  desc 'set build number with the run number'
   private_lane :bump_build do
     increment_build_number(
       build_number: number_of_commits,

--- a/sample/ios/fastlane/Fastfile
+++ b/sample/ios/fastlane/Fastfile
@@ -141,7 +141,7 @@ platform :ios do
   desc 'set build number with the run number'
   private_lane :bump_build do
     increment_build_number(
-      build_number: number_of_commits,
+      build_number: Environments.GITHUB_RUN_NUMBER,
       xcodeproj: Constants.PROJECT_PATH
     )
   end

--- a/sample/pubspec.lock
+++ b/sample/pubspec.lock
@@ -193,6 +193,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.2"
+  equatable:
+    dependency: "direct main"
+    description:
+      name: equatable
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   fake_async:
     dependency: transitive
     description:
@@ -272,14 +280,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_svg:
-    dependency: "direct main"
-    description:
-      name: flutter_svg
-      sha256: "8c5d68a82add3ca76d792f058b186a0599414f279f00ece4830b9b231b570338"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.7"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -288,6 +288,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.6"
+  flutter_svg:
+    dependency: "direct main"
+    description:
+      name: flutter_svg
+      sha256: "8c5d68a82add3ca76d792f058b186a0599414f279f00ece4830b9b231b570338"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.7"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -391,6 +399,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  injectable_generator:
+    dependency: "direct dev"
+    description:
+      name: injectable_generator
+      sha256: "4fe3db041b680098ce3af40b680734906e955a0ce89170d3993626d48d27b2f3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.6"
   integration_test:
     dependency: "direct dev"
     description: flutter
@@ -532,6 +548,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      sha256: "63e5216aae014a72fe9579ccd027323395ce7a98271d9defa9d57320d001af81"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.4.3"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: "2ffaf52a21f64ac9b35fe7369bb9533edbd4f698e5604db8645b1064ff4cf221"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.3.3"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: "99e220bce3f8877c78e4ace901082fb29fa1b4ebde529ad0932d8d664b34f3f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.4"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: "7c6b1500385dd1d2ca61bb89e2488ca178e274a69144d26bbd65e33eae7c02a9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.11.3"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: cc074aace208760f1eee6aa4fae766b45d947df85bc831cde77009cdb4720098
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3"
   petitparser:
     dependency: transitive
     description:
@@ -588,6 +644,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.3"
+  recase:
+    dependency: transitive
+    description:
+      name: recase
+      sha256: e4eb4ec2dcdee52dcf99cb4ceabaffc631d7424ee55e56f280bc039737f89213
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   retrofit:
     dependency: "direct main"
     description:


### PR DESCRIPTION
- Solves #241

## What happened 👀

I add the `$GITHUB_RUN_NUMBER` as the build number for iOS when building the app.

## Insight 📝

I add the `$GITHUB_RUN_NUMBER` as the build number for iOS when building the app for both `/.github/workflows/ios_deploy_staging_to_firebase.yml` and `/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/ios_deploy_staging_to_firebase.yml`

## Proof Of Work 📹

[Build with run number `45`](https://github.com/nimblehq/flutter-templates/actions/runs/5721838341/job/15504015968?pr=250)

<img width="1279" alt="image" src="https://github.com/nimblehq/flutter-templates/assets/23162627/407cc0a5-1fc1-4dd6-b093-4a6ef17f41d2">