### PR TITLE
[#229] [Android] Add missing signing config in CD workflows

### DIFF
--- a/.github/workflows/android_deploy_production_to_playstore.yml
+++ b/.github/workflows/android_deploy_production_to_playstore.yml
@@ -47,6 +47,14 @@ jobs:
         run: |
           echo $ENV_PRODUCTION > .env
 
+      - name: Set up release signing configs
+        env:
+          ANDROID_RELEASE_KEYSTORE_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_BASE64 }}
+          ANDROID_SIGNING_PROPERTIES_BASE64: ${{ secrets.ANDROID_SIGNING_PROPERTIES_BASE64 }}
+        run: |
+          echo $ANDROID_RELEASE_KEYSTORE_BASE64 | base64 --decode > android/config/release.keystore
+          echo $ANDROID_SIGNING_PROPERTIES_BASE64 | base64 --decode > android/signing.properties
+
       - name: Build Production App Bundle
         run: flutter build appbundle --flavor production --release --build-number $GITHUB_RUN_NUMBER
 

--- a/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/android_deploy_production_to_playstore.yml
+++ b/bricks/template/__brick__/{{project_name.snakeCase()}}/.github/workflows/android_deploy_production_to_playstore.yml
@@ -38,6 +38,14 @@ jobs:
         run: |
           echo $ENV_PRODUCTION > .env
 
+      - name: Set up release signing configs
+        env:
+          ANDROID_RELEASE_KEYSTORE_BASE64: ${{#mustacheCase}}secrets.ANDROID_RELEASE_KEYSTORE_BASE64{{/mustacheCase}}
+          ANDROID_SIGNING_PROPERTIES_BASE64: ${{#mustacheCase}}secrets.ANDROID_SIGNING_PROPERTIES_BASE64{{/mustacheCase}}
+        run: |
+          echo $ANDROID_RELEASE_KEYSTORE_BASE64 | base64 --decode > android/config/release.keystore
+          echo $ANDROID_SIGNING_PROPERTIES_BASE64 | base64 --decode > android/signing.properties
+
       - name: Build Production App Bundle
         run: flutter build appbundle --flavor production --release --build-number $GITHUB_RUN_NUMBER
 


### PR DESCRIPTION
- Solves #229

## What happened 👀

- Add a new step (which was missed from https://github.com/nimblehq/flutter-templates/pull/251) to set up release signing configs: keystore & signing.properties.

## Insight 📝

- This step is needed only when building the `release` build.
- We must use `base64` to encode and decode the keystore & signing.properties to ensure the binary file content.

## Proof Of Work 📹

https://github.com/nimblehq/flutter-templates/actions/runs/5722187525/job/15504868438 ✅ 