### PR TITLE
[#198] Generate and add "release notes" when distributing new builds on Firebase (staging and production)

### DIFF
--- a/.github/workflows/android_deploy_production.yml
+++ b/.github/workflows/android_deploy_production.yml
@@ -57,10 +57,15 @@ jobs:
       - name: Build Android apk
         run: flutter build apk --flavor production --release --build-number $GITHUB_RUN_NUMBER
 
+      - name: Get PR information
+        uses: 8BitJonny/gh-get-current-pr@2.2.0
+        id: PR
+
       - name: Deploy Android Production to Firebase
         uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
         with:
           appId: ${{ vars.FIREBASE_ANDROID_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON }}
           groups: ${{ vars.FIREBASE_DISTRIBUTION_TESTER_GROUPS }}
+          releaseNotes: ${{ steps.PR.outputs.pr_body }}
           file: build/app/outputs/flutter-apk/app-production-release.apk

--- a/.github/workflows/android_deploy_production.yml
+++ b/.github/workflows/android_deploy_production.yml
@@ -57,9 +57,18 @@ jobs:
       - name: Build Android apk
         run: flutter build apk --flavor production --release --build-number $GITHUB_RUN_NUMBER
 
-      - name: Get PR information
-        uses: 8BitJonny/gh-get-current-pr@2.2.0
-        id: PR
+      - name: Find HEAD commit
+        id: head
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Build changelog on "main"
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v4
+        with:
+          configuration: ".github/workflows/configs/changelog-config.json"
+          # Listing PRs from the last tag to the HEAD commit
+          toTag: ${{ steps.head.outputs.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy Android Production to Firebase
         uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
@@ -67,5 +76,5 @@ jobs:
           appId: ${{ vars.FIREBASE_ANDROID_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON }}
           groups: ${{ vars.FIREBASE_DISTRIBUTION_TESTER_GROUPS }}
-          releaseNotes: ${{ steps.PR.outputs.pr_body }}
+          releaseNotes: ${{ steps.changelog.outputs.changelog }}
           file: build/app/outputs/flutter-apk/app-production-release.apk

--- a/.github/workflows/android_deploy_staging.yml
+++ b/.github/workflows/android_deploy_staging.yml
@@ -49,9 +49,25 @@ jobs:
       - name: Build Android apk
         run: flutter build apk --flavor staging --debug --build-number $GITHUB_RUN_NUMBER
 
-      - name: Get PR information
-        uses: 8BitJonny/gh-get-current-pr@2.2.0
-        id: PR
+      - name: Find HEAD commit
+        id: head
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Limit changelog to the latest pull request only
+        uses: jossef/action-set-json-field@v2
+        with:
+          file: .github/workflows/configs/changelog-config.json
+          field: max_pull_requests
+          value: 1
+
+      - name: Build changelog on "develop"
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v4
+        with:
+          configuration: ".github/workflows/configs/changelog-config.json"
+          # Listing PRs from the last tag to the HEAD commit
+          toTag: ${{ steps.head.outputs.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy Android Staging to Firebase
         uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
@@ -59,5 +75,5 @@ jobs:
           appId: ${{ vars.FIREBASE_ANDROID_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON }}
           groups: ${{ vars.FIREBASE_DISTRIBUTION_TESTER_GROUPS }}
-          releaseNotes: ${{ steps.PR.outputs.pr_title }}
+          releaseNotes: ${{ steps.changelog.outputs.changelog }}
           file: build/app/outputs/flutter-apk/app-staging-debug.apk

--- a/.github/workflows/android_deploy_staging.yml
+++ b/.github/workflows/android_deploy_staging.yml
@@ -49,10 +49,15 @@ jobs:
       - name: Build Android apk
         run: flutter build apk --flavor staging --debug --build-number $GITHUB_RUN_NUMBER
 
+      - name: Get PR information
+        uses: 8BitJonny/gh-get-current-pr@2.2.0
+        id: PR
+
       - name: Deploy Android Staging to Firebase
         uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
         with:
           appId: ${{ vars.FIREBASE_ANDROID_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON }}
           groups: ${{ vars.FIREBASE_DISTRIBUTION_TESTER_GROUPS }}
+          releaseNotes: ${{ steps.PR.outputs.pr_title }}
           file: build/app/outputs/flutter-apk/app-staging-debug.apk

--- a/.github/workflows/configs/changelog-config.json
+++ b/.github/workflows/configs/changelog-config.json
@@ -1,0 +1,32 @@
+{
+  "categories": [
+    {
+      "title": "## ✨ Features",
+      "labels": [
+        "type : feature"
+      ]
+    },
+    {
+      "title": "## 🐛 Bug fixes",
+      "labels": [
+        "type : bug"
+      ]
+    },
+    {
+      "title": "## 🧹 Chores",
+      "labels": [
+        "type : chore"
+      ]
+    },
+    {
+      "title": "## Others",
+      "exclude_labels": [
+        "type : feature",
+        "type : bug",
+        "type : chore",
+        "type : release"
+      ]
+    }
+  ],
+  "max_pull_requests": 200
+}

--- a/.github/workflows/ios_deploy_staging_to_firebase.yml
+++ b/.github/workflows/ios_deploy_staging_to_firebase.yml
@@ -52,9 +52,25 @@ jobs:
         run: |
           echo -e "$ENV" > .env.staging
 
-      - name: Get PR information
-        uses: 8BitJonny/gh-get-current-pr@2.2.0
-        id: PR
+      - name: Find HEAD commit
+        id: head
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Limit changelog to the latest pull request only
+        uses: jossef/action-set-json-field@v2
+        with:
+          file: .github/workflows/configs/changelog-config.json
+          field: max_pull_requests
+          value: 1
+
+      - name: Build changelog on "develop"
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v4
+        with:
+          configuration: ".github/workflows/configs/changelog-config.json"
+          # Listing PRs from the last tag to the HEAD commit
+          toTag: ${{ steps.head.outputs.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run code generator
         run: flutter packages pub run build_runner build --delete-conflicting-outputs
@@ -70,6 +86,6 @@ jobs:
 
       - name: Deploy to Firebase
         env:
-          RELEASE_NOTE_CONTENT: ${{ steps.PR.outputs.pr_title }}
+          RELEASE_NOTE_CONTENT: ${{ steps.changelog.outputs.changelog }}
         run: |
           cd ./ios && bundle exec fastlane build_and_upload_staging_app

--- a/.github/workflows/ios_deploy_staging_to_firebase.yml
+++ b/.github/workflows/ios_deploy_staging_to_firebase.yml
@@ -52,6 +52,10 @@ jobs:
         run: |
           echo -e "$ENV" > .env.staging
 
+      - name: Get PR information
+        uses: 8BitJonny/gh-get-current-pr@2.2.0
+        id: PR
+
       - name: Run code generator
         run: flutter packages pub run build_runner build --delete-conflicting-outputs
 
@@ -65,5 +69,7 @@ jobs:
         run: cd ./ios && bundle exec fastlane sync_adhoc_staging_signing
 
       - name: Deploy to Firebase
+        env:
+          RELEASE_NOTE_CONTENT: ${{ steps.PR.outputs.pr_title }}
         run: |
           cd ./ios && bundle exec fastlane build_and_upload_staging_app

--- a/bricks/template/__brick__/.github/workflows/android_deploy_production.yml
+++ b/bricks/template/__brick__/.github/workflows/android_deploy_production.yml
@@ -51,9 +51,18 @@ jobs:
       - name: Build Android apk
         run: flutter build apk --flavor production --release --build-number $GITHUB_RUN_NUMBER
 
-      - name: Get PR information
-        uses: 8BitJonny/gh-get-current-pr@2.2.0
-        id: PR
+      - name: Find HEAD commit
+        id: head
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Build changelog on "main"
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v4
+        with:
+          configuration: ".github/workflows/configs/changelog-config.json"
+          # Listing PRs from the last tag to the HEAD commit
+          toTag: ${{#mustacheCase}}steps.head.outputs.sha{{/mustacheCase}}
+          token: ${{#mustacheCase}}secrets.GITHUB_TOKEN{{/mustacheCase}}
 
       - name: Deploy Android Production to Firebase
         uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
@@ -61,5 +70,5 @@ jobs:
           appId: ${{#mustacheCase}}vars.FIREBASE_ANDROID_APP_ID{{/mustacheCase}}
           serviceCredentialsFileContent: ${{#mustacheCase}}secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON{{/mustacheCase}}
           groups: ${{#mustacheCase}}vars.FIREBASE_DISTRIBUTION_TESTER_GROUPS{{/mustacheCase}}
-          releaseNotes: ${{#mustacheCase}}steps.PR.outputs.pr_body{{/mustacheCase}}
+          releaseNotes: ${{#mustacheCase}}steps.changelog.outputs.changelog{{/mustacheCase}}
           file: build/app/outputs/flutter-apk/app-production-release.apk

--- a/bricks/template/__brick__/.github/workflows/android_deploy_production.yml
+++ b/bricks/template/__brick__/.github/workflows/android_deploy_production.yml
@@ -51,10 +51,15 @@ jobs:
       - name: Build Android apk
         run: flutter build apk --flavor production --release --build-number $GITHUB_RUN_NUMBER
 
+      - name: Get PR information
+        uses: 8BitJonny/gh-get-current-pr@2.2.0
+        id: PR
+
       - name: Deploy Android Production to Firebase
         uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
         with:
           appId: ${{#mustacheCase}}vars.FIREBASE_ANDROID_APP_ID{{/mustacheCase}}
           serviceCredentialsFileContent: ${{#mustacheCase}}secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON{{/mustacheCase}}
           groups: ${{#mustacheCase}}vars.FIREBASE_DISTRIBUTION_TESTER_GROUPS{{/mustacheCase}}
+          releaseNotes: ${{#mustacheCase}}steps.PR.outputs.pr_body{{/mustacheCase}}
           file: build/app/outputs/flutter-apk/app-production-release.apk

--- a/bricks/template/__brick__/.github/workflows/android_deploy_staging.yml
+++ b/bricks/template/__brick__/.github/workflows/android_deploy_staging.yml
@@ -43,10 +43,15 @@ jobs:
       - name: Build Android apk
         run: flutter build apk --flavor staging --debug --build-number $GITHUB_RUN_NUMBER
 
+      - name: Get PR information
+        uses: 8BitJonny/gh-get-current-pr@2.2.0
+        id: PR
+
       - name: Deploy Android Staging to Firebase
         uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
         with:
           appId: ${{#mustacheCase}}vars.FIREBASE_ANDROID_APP_ID{{/mustacheCase}}
           serviceCredentialsFileContent: ${{#mustacheCase}}secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON{{/mustacheCase}}
           groups: ${{#mustacheCase}}vars.FIREBASE_DISTRIBUTION_TESTER_GROUPS{{/mustacheCase}}
+          releaseNotes: ${{#mustacheCase}}steps.PR.outputs.pr_title{{/mustacheCase}}
           file: build/app/outputs/flutter-apk/app-staging-debug.apk

--- a/bricks/template/__brick__/.github/workflows/android_deploy_staging.yml
+++ b/bricks/template/__brick__/.github/workflows/android_deploy_staging.yml
@@ -43,9 +43,25 @@ jobs:
       - name: Build Android apk
         run: flutter build apk --flavor staging --debug --build-number $GITHUB_RUN_NUMBER
 
-      - name: Get PR information
-        uses: 8BitJonny/gh-get-current-pr@2.2.0
-        id: PR
+      - name: Find HEAD commit
+        id: head
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Limit changelog to the latest pull request only
+        uses: jossef/action-set-json-field@v2
+        with:
+          file: .github/workflows/configs/changelog-config.json
+          field: max_pull_requests
+          value: 1
+
+      - name: Build changelog on "develop"
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v4
+        with:
+          configuration: ".github/workflows/configs/changelog-config.json"
+          # Listing PRs from the last tag to the HEAD commit
+          toTag: ${{#mustacheCase}}steps.head.outputs.sha{{/mustacheCase}}
+          token: ${{#mustacheCase}}secrets.GITHUB_TOKEN{{/mustacheCase}}
 
       - name: Deploy Android Staging to Firebase
         uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
@@ -53,5 +69,5 @@ jobs:
           appId: ${{#mustacheCase}}vars.FIREBASE_ANDROID_APP_ID{{/mustacheCase}}
           serviceCredentialsFileContent: ${{#mustacheCase}}secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON{{/mustacheCase}}
           groups: ${{#mustacheCase}}vars.FIREBASE_DISTRIBUTION_TESTER_GROUPS{{/mustacheCase}}
-          releaseNotes: ${{#mustacheCase}}steps.PR.outputs.pr_title{{/mustacheCase}}
+          releaseNotes: ${{#mustacheCase}}steps.changelog.outputs.changelog{{/mustacheCase}}
           file: build/app/outputs/flutter-apk/app-staging-debug.apk

--- a/bricks/template/__brick__/.github/workflows/configs/changelog-config.json
+++ b/bricks/template/__brick__/.github/workflows/configs/changelog-config.json
@@ -1,0 +1,32 @@
+{
+  "categories": [
+    {
+      "title": "## ✨ Features",
+      "labels": [
+        "type : feature"
+      ]
+    },
+    {
+      "title": "## 🐛 Bug fixes",
+      "labels": [
+        "type : bug"
+      ]
+    },
+    {
+      "title": "## 🧹 Chores",
+      "labels": [
+        "type : chore"
+      ]
+    },
+    {
+      "title": "## Others",
+      "exclude_labels": [
+        "type : feature",
+        "type : bug",
+        "type : chore",
+        "type : release"
+      ]
+    }
+  ],
+  "max_pull_requests": 200
+}

--- a/bricks/template/__brick__/.github/workflows/ios_deploy_staging_to_firebase.yml
+++ b/bricks/template/__brick__/.github/workflows/ios_deploy_staging_to_firebase.yml
@@ -46,9 +46,25 @@ jobs:
         run: |
           echo -e "$ENV" > .env.staging
 
-      - name: Get PR information
-        uses: 8BitJonny/gh-get-current-pr@2.2.0
-        id: PR
+      - name: Find HEAD commit
+        id: head
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Limit changelog to the latest pull request only
+        uses: jossef/action-set-json-field@v2
+        with:
+          file: .github/workflows/configs/changelog-config.json
+          field: max_pull_requests
+          value: 1
+
+      - name: Build changelog on "develop"
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v4
+        with:
+          configuration: ".github/workflows/configs/changelog-config.json"
+          # Listing PRs from the last tag to the HEAD commit
+          toTag: ${{#mustacheCase}}steps.head.outputs.sha{{/mustacheCase}}
+          token: ${{#mustacheCase}}secrets.GITHUB_TOKEN{{/mustacheCase}}
 
       - name: Run code generator
         run: flutter packages pub run build_runner build --delete-conflicting-outputs
@@ -64,6 +80,6 @@ jobs:
 
       - name: Deploy to Firebase
         env:
-          RELEASE_NOTE_CONTENT: ${{ steps.PR.outputs.pr_title }}
+          RELEASE_NOTE_CONTENT:${{#mustacheCase}}steps.changelog.outputs.changelog{{/mustacheCase}}
         run: |
           cd ./ios && bundle exec fastlane build_and_upload_staging_app

--- a/bricks/template/__brick__/.github/workflows/ios_deploy_staging_to_firebase.yml
+++ b/bricks/template/__brick__/.github/workflows/ios_deploy_staging_to_firebase.yml
@@ -46,6 +46,10 @@ jobs:
         run: |
           echo -e "$ENV" > .env.staging
 
+      - name: Get PR information
+        uses: 8BitJonny/gh-get-current-pr@2.2.0
+        id: PR
+
       - name: Run code generator
         run: flutter packages pub run build_runner build --delete-conflicting-outputs
 
@@ -59,5 +63,7 @@ jobs:
         run: cd ./ios && bundle exec fastlane sync_adhoc_staging_signing
 
       - name: Deploy to Firebase
+        env:
+          RELEASE_NOTE_CONTENT: ${{ steps.PR.outputs.pr_title }}
         run: |
           cd ./ios && bundle exec fastlane build_and_upload_staging_app

--- a/bricks/template/__brick__/ios/fastlane/Constants/Environments.rb
+++ b/bricks/template/__brick__/ios/fastlane/Constants/Environments.rb
@@ -44,6 +44,10 @@ class Environments
   end
 
   def self.GITHUB_RUN_NUMBER
-    ENV["GITHUB_RUN_NUMBER"]
+    ENV['GITHUB_RUN_NUMBER']
+  end
+
+  def self.RELEASE_NOTE_CONTENT
+    ENV['RELEASE_NOTE_CONTENT']
   end
 end

--- a/bricks/template/__brick__/ios/fastlane/Fastfile
+++ b/bricks/template/__brick__/ios/fastlane/Fastfile
@@ -211,7 +211,7 @@ platform :ios do
       product_name: options[:product_name],
       firebase_app_id: options[:firebase_app_id],
       tester_groups: options[:tester_groups],
-      notes: ""
+      notes: Environments.RELEASE_NOTE_CONTENT
     )
   end
 end

--- a/sample/.github/workflows/android_deploy_production.yml
+++ b/sample/.github/workflows/android_deploy_production.yml
@@ -51,9 +51,18 @@ jobs:
       - name: Build Android apk
         run: flutter build apk --flavor production --release --build-number $GITHUB_RUN_NUMBER
 
-      - name: Get PR information
-        uses: 8BitJonny/gh-get-current-pr@2.2.0
-        id: PR
+      - name: Find HEAD commit
+        id: head
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Build changelog on "main"
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v4
+        with:
+          configuration: ".github/workflows/configs/changelog-config.json"
+          # Listing PRs from the last tag to the HEAD commit
+          toTag: ${{ steps.head.outputs.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy Android Production to Firebase
         uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
@@ -61,5 +70,5 @@ jobs:
           appId: ${{ vars.FIREBASE_ANDROID_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON }}
           groups: ${{ vars.FIREBASE_DISTRIBUTION_TESTER_GROUPS }}
-          releaseNotes: ${{ steps.PR.outputs.pr_body }}
-          file: build/app/outputs/flutter-apk/app-production-debug.apk
+          releaseNotes: ${{ steps.changelog.outputs.changelog }}
+          file: build/app/outputs/flutter-apk/app-production-release.apk

--- a/sample/.github/workflows/android_deploy_production.yml
+++ b/sample/.github/workflows/android_deploy_production.yml
@@ -51,10 +51,15 @@ jobs:
       - name: Build Android apk
         run: flutter build apk --flavor production --release --build-number $GITHUB_RUN_NUMBER
 
+      - name: Get PR information
+        uses: 8BitJonny/gh-get-current-pr@2.2.0
+        id: PR
+
       - name: Deploy Android Production to Firebase
         uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
         with:
           appId: ${{ vars.FIREBASE_ANDROID_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON }}
           groups: ${{ vars.FIREBASE_DISTRIBUTION_TESTER_GROUPS }}
-          file: build/app/outputs/flutter-apk/app-production-release.apk
+          releaseNotes: ${{ steps.PR.outputs.pr_body }}
+          file: build/app/outputs/flutter-apk/app-production-debug.apk

--- a/sample/.github/workflows/android_deploy_staging.yml
+++ b/sample/.github/workflows/android_deploy_staging.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Limit changelog to the latest pull request only
         uses: jossef/action-set-json-field@v2
         with:
-          file: .github/workflows/changelog-config.json
+          file: .github/workflows/configs/changelog-config.json
           field: max_pull_requests
           value: 1
 

--- a/sample/.github/workflows/android_deploy_staging.yml
+++ b/sample/.github/workflows/android_deploy_staging.yml
@@ -43,10 +43,15 @@ jobs:
       - name: Build Android apk
         run: flutter build apk --flavor staging --debug --build-number $GITHUB_RUN_NUMBER
 
+      - name: Get PR information
+        uses: 8BitJonny/gh-get-current-pr@2.2.0
+        id: PR
+
       - name: Deploy Android Staging to Firebase
         uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
         with:
           appId: ${{ vars.FIREBASE_ANDROID_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON }}
           groups: ${{ vars.FIREBASE_DISTRIBUTION_TESTER_GROUPS }}
+          releaseNotes: ${{ steps.PR.outputs.pr_title }}
           file: build/app/outputs/flutter-apk/app-staging-debug.apk

--- a/sample/.github/workflows/android_deploy_staging.yml
+++ b/sample/.github/workflows/android_deploy_staging.yml
@@ -43,9 +43,25 @@ jobs:
       - name: Build Android apk
         run: flutter build apk --flavor staging --debug --build-number $GITHUB_RUN_NUMBER
 
-      - name: Get PR information
-        uses: 8BitJonny/gh-get-current-pr@2.2.0
-        id: PR
+      - name: Find HEAD commit
+        id: head
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Limit changelog to the latest pull request only
+        uses: jossef/action-set-json-field@v2
+        with:
+          file: .github/workflows/changelog-config.json
+          field: max_pull_requests
+          value: 1
+
+      - name: Build changelog on "develop"
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v4
+        with:
+          configuration: ".github/workflows/configs/changelog-config.json"
+          # Listing PRs from the last tag to the HEAD commit
+          toTag: ${{ steps.head.outputs.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy Android Staging to Firebase
         uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
@@ -53,5 +69,5 @@ jobs:
           appId: ${{ vars.FIREBASE_ANDROID_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON }}
           groups: ${{ vars.FIREBASE_DISTRIBUTION_TESTER_GROUPS }}
-          releaseNotes: ${{ steps.PR.outputs.pr_title }}
+          releaseNotes: ${{ steps.changelog.outputs.changelog }}
           file: build/app/outputs/flutter-apk/app-staging-debug.apk

--- a/sample/.github/workflows/configs/changelog-config.json
+++ b/sample/.github/workflows/configs/changelog-config.json
@@ -1,0 +1,32 @@
+{
+  "categories": [
+    {
+      "title": "## ✨ Features",
+      "labels": [
+        "type : feature"
+      ]
+    },
+    {
+      "title": "## 🐛 Bug fixes",
+      "labels": [
+        "type : bug"
+      ]
+    },
+    {
+      "title": "## 🧹 Chores",
+      "labels": [
+        "type : chore"
+      ]
+    },
+    {
+      "title": "## Others",
+      "exclude_labels": [
+        "type : feature",
+        "type : bug",
+        "type : chore",
+        "type : release"
+      ]
+    }
+  ],
+  "max_pull_requests": 200
+}

--- a/sample/.github/workflows/ios_deploy_staging_to_firebase.yml
+++ b/sample/.github/workflows/ios_deploy_staging_to_firebase.yml
@@ -46,16 +46,25 @@ jobs:
         run: |
           echo -e "$ENV" > .env.staging
 
-            - name: Get PR information
-        uses: 8BitJonny/gh-get-current-pr@2.2.0
-        id: PR
+      - name: Find HEAD commit
+        id: head
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Generate release notes
-        id: generate-release-notes
-        env:
-          PR_TITLE: ${{ steps.PR.outputs.pr_title }}
-        run: |
-          echo "RELEASE_NOTE_CONTENT=$PR_TITLE" >> $GITHUB_ENV
+      - name: Limit changelog to the latest pull request only
+        uses: jossef/action-set-json-field@v2
+        with:
+          file: .github/workflows/changelog-config.json
+          field: max_pull_requests
+          value: 1
+
+      - name: Build changelog on "develop"
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v4
+        with:
+          configuration: ".github/workflows/configs/changelog-config.json"
+          # Listing PRs from the last tag to the HEAD commit
+          toTag: ${{ steps.head.outputs.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run code generator
         run: flutter packages pub run build_runner build --delete-conflicting-outputs
@@ -70,5 +79,7 @@ jobs:
         run: cd ./ios && bundle exec fastlane sync_adhoc_staging_signing
 
       - name: Deploy to Firebase
+        env:
+          RELEASE_NOTE_CONTENT:${{ steps.changelog.outputs.changelog }}
         run: |
           cd ./ios && bundle exec fastlane build_and_upload_staging_app

--- a/sample/.github/workflows/ios_deploy_staging_to_firebase.yml
+++ b/sample/.github/workflows/ios_deploy_staging_to_firebase.yml
@@ -46,6 +46,17 @@ jobs:
         run: |
           echo -e "$ENV" > .env.staging
 
+            - name: Get PR information
+        uses: 8BitJonny/gh-get-current-pr@2.2.0
+        id: PR
+
+      - name: Generate release notes
+        id: generate-release-notes
+        env:
+          PR_TITLE: ${{ steps.PR.outputs.pr_title }}
+        run: |
+          echo "RELEASE_NOTE_CONTENT=$PR_TITLE" >> $GITHUB_ENV
+
       - name: Run code generator
         run: flutter packages pub run build_runner build --delete-conflicting-outputs
 

--- a/sample/.github/workflows/ios_deploy_staging_to_firebase.yml
+++ b/sample/.github/workflows/ios_deploy_staging_to_firebase.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Limit changelog to the latest pull request only
         uses: jossef/action-set-json-field@v2
         with:
-          file: .github/workflows/changelog-config.json
+          file: .github/workflows/configs/changelog-config.json
           field: max_pull_requests
           value: 1
 

--- a/sample/ios/fastlane/Constants/Environments.rb
+++ b/sample/ios/fastlane/Constants/Environments.rb
@@ -44,6 +44,10 @@ class Environments
   end
 
   def self.GITHUB_RUN_NUMBER
-    ENV["GITHUB_RUN_NUMBER"]
+    ENV['GITHUB_RUN_NUMBER']
+  end
+
+  def self.RELEASE_NOTE_CONTENT
+    ENV['RELEASE_NOTE_CONTENT']
   end
 end

--- a/sample/ios/fastlane/Fastfile
+++ b/sample/ios/fastlane/Fastfile
@@ -211,7 +211,7 @@ platform :ios do
       product_name: options[:product_name],
       firebase_app_id: options[:firebase_app_id],
       tester_groups: options[:tester_groups],
-      notes: ""
+      notes: Environments.RELEASE_NOTE_CONTENT
     )
   end
 end


### PR DESCRIPTION
- Close #198 

## What happened 👀

- Use `mikepenz/release-changelog-builder-action` to generate change log
- Find and use HEAD commit for prudction build
- Apply `Limit changelog to the latest pull request only` for staging
- Add `changelog-config.json` file


## Insight 📝

- I was trying to use `echo "RELEASE_NOTE_CONTENT="$((git log -1 --merges | grep "\[") | grep . && echo "" || echo $(git log -1 --merges --format=%B))""` for staging flow (android and iOS)

and  Add `echo "RELEASE_NOTE_CONTENT="$(git log --merges --pretty=%B $(git describe --abbrev=0 --tags)..HEAD | grep "\[")""` for production flow (Android only)

But neither of them works (showing empty value)

- Trying with `[8BitJonny/gh-get-current-pr](https://github.com/8BitJonny/gh-get-current-pr) is better, but it still does not meet our expectations. It is only able to get the PR title/content in raw text.

## Proof Of Work 📹

- Staging

<img width="940" alt="Screenshot 2023-11-10 at 3 37 42 PM" src="https://github.com/nimblehq/flutter-templates/assets/88996251/0d721bfd-157f-4e9c-a84d-faf2c96d217d">

- Production

<img width="937" alt="Screenshot 2023-11-10 at 3 42 41 PM" src="https://github.com/nimblehq/flutter-templates/assets/88996251/7ac00f2c-939e-4521-806d-2dfbdf9470b6">

